### PR TITLE
Immers login tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7264,12 +7264,6 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
-    "bowser": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.9.0.tgz",
-      "integrity": "sha512-2ld76tuLBNFekRgmJfT2+3j5MIrP6bFict8WAIT3beq+srz1gcKNAdNKMqHqauQt63NmAa88HfP1/Ypa9Er3HA==",
-      "dev": true
-    },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
@@ -12929,9 +12923,9 @@
       "requires": {
         "@types/debug": "^4.1.5",
         "@types/events": "^3.0.0",
-        "awaitqueue": "^2.2.3",
+        "awaitqueue": "^2.3.3",
         "bowser": "^2.11.0",
-        "debug": "^4.1.1",
+        "debug": "^4.3.1",
         "events": "^3.2.0",
         "h264-profile-level-id": "^1.0.1",
         "sdp-transform": "^2.14.0",
@@ -12944,6 +12938,12 @@
           "integrity": "sha512-vKY8hHHt1FT05UBxaTKWoA8+A3APnyzcOO1UBY5wQ7ENzXCFi3Yy4wSKsqrO0ncDD/5CI6IZDN1nVZQKziWIqg==",
           "dev": true
         },
+        "bowser": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+          "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+          "dev": true
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -12954,9 +12954,9 @@
           }
         },
         "events": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-          "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+          "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
           "dev": true
         },
         "has-flag": {
@@ -12972,9 +12972,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -19445,6 +19445,11 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "web-monetization-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/web-monetization-polyfill/-/web-monetization-polyfill-1.0.0.tgz",
+      "integrity": "sha512-lNEkyOtXXdSppvrfTes2/x5LyTCxe7X33at559QC+UM8lHWmEK+6i00iSr78geaM7KCw3paXH16ZR2uFpLEXbw=="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -101,8 +101,8 @@
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
     "screenfull": "^4.0.1",
-    "socket.io-client": "^2.3.0",
     "semver": "^7.3.2",
+    "socket.io-client": "^2.3.0",
     "three": "github:mozillareality/three.js#hubs/master",
     "three-ammo": "^1.0.11",
     "three-bmfont-text": "github:mozillareality/three-bmfont-text#hubs/master",
@@ -110,6 +110,7 @@
     "three-pathfinding": "github:MozillaReality/three-pathfinding#hubs/master2",
     "three-to-ammo": "github:infinitelee/three-to-ammo",
     "uuid": "^3.2.1",
+    "web-monetization-polyfill": "^1.0.0",
     "webrtc-adapter": "^6.0.2",
     "zip-loader": "^1.1.0"
   },

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -42,7 +42,7 @@
   "sign-in.tweet": "You'll need to sign in to send tweets.",
   "sign-in.tweet-complete": "You are now signed in.",
   "sign-in.as": "Signed in as",
-  "sign-in.in": "Sign In",
+  "sign-in.in": " ",
   "sign-in.out": "Sign Out",
   "room-settings.apply": "Apply",
   "room-settings.name-subtitle": "Room Name",

--- a/src/assets/locales/zh.json
+++ b/src/assets/locales/zh.json
@@ -42,7 +42,7 @@
   "sign-in.tweet": "只有登陆才可以发送信息。",
   "sign-in.tweet-complete": "你已经登陆。",
   "sign-in.as": "登录为",
-  "sign-in.in": "登录",
+  "sign-in.in": " ",
   "sign-in.out": "退出",
   "room-settings.apply": "递交",
   "room-settings.name-subtitle": "房间名称",

--- a/src/hub.js
+++ b/src/hub.js
@@ -183,6 +183,8 @@ if (isEmbed && !qs.get("embed_token")) {
   throw new Error("no embed token");
 }
 
+immers.auth(store);
+
 THREE.Object3D.DefaultMatrixAutoUpdate = false;
 
 import "./components/owned-object-limiter";
@@ -496,7 +498,6 @@ function handleHubChannelJoined(entryManager, hubChannel, messageDispatch, data)
     }
   }
 
-  immers.auth(store, hub);
   console.log(`Janus host: ${hub.host}:${hub.port}`);
 
   remountUI({

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -121,7 +121,7 @@ export async function getFriends(actorObj) {
 }
 
 // perform oauth flow to get access token for local or remote user
-export async function auth(store, hub) {
+export async function auth(store) {
   const loc = new URL(window.location);
   const hashParams = new URLSearchParams(loc.hash.substring(1));
   const hubUri = new URL(window.location);
@@ -144,9 +144,7 @@ export async function auth(store, hub) {
     redirect.search = new URLSearchParams({
       client_id: place.id,
       redirect_uri: hubUri,
-      response_type: "token",
-      shortlink_domain: configs.SHORTLINK_DOMAIN,
-      entry_code: hub.entry_code
+      response_type: "token"
     }).toString();
     // hide error messages caused by interrupting loading to redirect
     try {

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -148,6 +148,12 @@ export async function auth(store, hub) {
       shortlink_domain: configs.SHORTLINK_DOMAIN,
       entry_code: hub.entry_code
     }).toString();
+    // hide error messages caused by interrupting loading to redirect
+    try {
+      document.getElementById("ui-root").style.display = "none";
+    } catch (ignore) {
+      /* ignore */
+    }
     window.location = redirect;
   };
 

--- a/src/utils/immers/monetization.js
+++ b/src/utils/immers/monetization.js
@@ -14,6 +14,8 @@
  *      totalAmoint: Number, amount received so far during this session
  *      currency: String, currency of the transation
  */
+import "web-monetization-polyfill";
+
 const monetization = {
   amountPaid: 0,
   currency: undefined,
@@ -49,12 +51,7 @@ function onMonetizationProgress(event) {
   }
 }
 
-// checks availability and adds event handlers
 function onSceneLoaded() {
-  if (!document.monetization) {
-    hubScene.emit("immers-monetization-unavailable");
-    return;
-  }
   if (document.monetization.state === "started") {
     onMonetizationStart();
   }


### PR DESCRIPTION
Small tweaks as a part of the login UX overhaul:

* No more confusing "Scene failed to load" error when redirecting to login
* Hide the hubs/reticulum sign in links (for now)
* Revert the changes from passing room link info the immers login that are no longer used
* Some code I found uncommited in my working directory :sweat_smile: to install the web-monetization-poyfill as a workaround for Content Security Policy preventing the Coil add-on from injecting the polyfill itself