### PR TITLE
Personal Avatar Collections

### DIFF
--- a/src/components/monetization-visible.js
+++ b/src/components/monetization-visible.js
@@ -38,7 +38,7 @@ AFRAME.registerSystem("monetization-visible", {
     const mv = "monetization-visible";
     for (const record of records) {
       for (const node of record.addedNodes) {
-        if (!node.nodeType === document.ELEMENT_NODE) continue;
+        if (!(node.nodeType === document.ELEMENT_NODE)) continue;
         if (node.classList.contains(mv)) node.setAttribute(mv, {});
         for (const descendant of node.querySelectorAll(`.${mv}`)) {
           descendant.setAttribute(mv, {});

--- a/src/react-components/media-tiles.js
+++ b/src/react-components/media-tiles.js
@@ -198,7 +198,7 @@ class MediaTiles extends Component {
           {thumbnailElement}
         </a>
         <div className={styles.tileActions}>
-          {entry.type === "avatar" && (
+          {/*disabled*/ entry.type === "__avatar" && (
             <StateLink
               stateKey="overlay"
               stateValue="avatar-editor"

--- a/src/storage/media-search-store.js
+++ b/src/storage/media-search-store.js
@@ -2,6 +2,7 @@ import { EventTarget } from "event-target-shim";
 import configs from "../utils/configs";
 import { getReticulumFetchUrl, fetchReticulumAuthenticated, hasReticulumServer } from "../utils/phoenix-utils";
 import { pushHistoryPath, sluglessPath, withSlug } from "../utils/history";
+import { fetchMyImmersAvatars } from "../utils/immers";
 
 const EMPTY_RESULT = { entries: [], meta: {} };
 
@@ -108,11 +109,16 @@ export default class MediaSearchStore extends EventTarget {
 
     this.isFetching = true;
     this.dispatchEvent(new CustomEvent("statechanged"));
-    const result = fetch ? await fetchReticulumAuthenticated(path) : EMPTY_RESULT;
+    let result = fetch ? await fetchReticulumAuthenticated(path) : EMPTY_RESULT;
+    // immers personal avatar collection
+    if (source === "avatars" && isMy) {
+      result = await fetchMyImmersAvatars(searchParams.get("cursor"));
+    }
 
     if (this.requestIndex != currentRequestIndex) return;
 
     this.result = result;
+
     this.nextCursor = this.result && this.result.meta && this.result.meta.next_cursor;
     this.lastFetchedUrl = url;
     this.isFetching = false;

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -3,7 +3,7 @@ import configs from "./configs";
 import { fetchAvatar } from "./avatar-utils";
 import { setupMonetization } from "./immers/monetization";
 const localImmer = configs.IMMERS_SERVER;
-console.log("immers.space client v0.3.0");
+console.log("immers.space client v0.4.0");
 // avoid race between auth and initialize code
 let resolveAuth;
 let rejectAuth;

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -4,6 +4,7 @@ import { fetchAvatar } from "./avatar-utils";
 import { setupMonetization } from "./immers/monetization";
 const localImmer = configs.IMMERS_SERVER;
 console.log("immers.space client v0.4.0");
+const jsonldMime = "application/activity+json";
 // avoid race between auth and initialize code
 let resolveAuth;
 let rejectAuth;
@@ -16,12 +17,13 @@ let place;
 let token;
 let hubScene;
 let localPlayer;
+let actorObj;
+let avatarsCollection;
+// map of avatar urls to model objects to avoid recreating their AP representation
+// when donned from personal avatars collection
+const myAvatars = {};
 
-export function getAvatarFromActor(actorObj) {
-  if (!actorObj.avatar) {
-    return null;
-  }
-  const avatar = Array.isArray(actorObj.avatar) ? actorObj.avatar[0] : actorObj.avatar;
+export function getUrlFromAvatar(avatar) {
   const links = Array.isArray(avatar.url) ? avatar.url : [avatar.url];
   // prefer gltf
   const gltfUrl = links.find(link => link.mediaType === "model/gltf+json" || link.mediaType === "model/gltf-binary");
@@ -32,9 +34,17 @@ export function getAvatarFromActor(actorObj) {
   return links.find(link => typeof link === "string");
 }
 
+export function getAvatarFromActor(actorObj) {
+  if (!actorObj.avatar) {
+    return null;
+  }
+  const avatar = Array.isArray(actorObj.avatar) ? actorObj.avatar[0] : actorObj.avatar;
+  getUrlFromAvatar(avatar);
+}
+
 export async function getObject(IRI) {
   if (IRI.startsWith(localImmer) || IRI.startsWith(homeImmer)) {
-    const headers = { Accept: "application/activity+json" };
+    const headers = { Accept: jsonldMime };
     if (token) {
       headers.Authorization = `Bearer ${token}`;
     }
@@ -51,7 +61,7 @@ export async function getObject(IRI) {
 export async function getActor() {
   const response = await window.fetch(`${homeImmer}/auth/me`, {
     headers: {
-      Accept: "application/activity+json",
+      Accept: jsonldMime,
       Authorization: `Bearer ${token}`
     }
   });
@@ -65,7 +75,7 @@ export function postActivity(outbox, activity) {
   return window.fetch(outbox, {
     method: "POST",
     headers: {
-      "Content-Type": "application/activity+json",
+      "Content-Type": jsonldMime,
       Authorization: `Bearer ${token}`
     },
     body: JSON.stringify(activity)
@@ -121,7 +131,8 @@ export async function createAvatar(actorObj, hubsAvatarId) {
       href: hubsAvatar.gltf_url,
       mediaType: hubsAvatar.gltf_url.includes(".glb") ? "model/gltf-binary" : "model/gltf+json"
     },
-    to: actorObj.followers
+    to: actorObj.followers,
+    generator: place.id
   };
   if (hubsAvatar.files.thumbnail) {
     immersAvatar.icon = hubsAvatar.files.thumbnail;
@@ -152,10 +163,69 @@ export async function createAvatar(actorObj, hubsAvatarId) {
   return created;
 }
 
+export async function fetchMyImmersAvatars(page) {
+  let collectionPage;
+  let items;
+  const hubsResult = {
+    meta: {
+      source: "avatar",
+      next_cursor: null
+    },
+    entries: [],
+    suggestions: null
+  };
+  if (!actorObj.streams?.avatars) {
+    return hubsResult;
+  }
+  try {
+    if (!avatarsCollection) {
+      // cache base collection object
+      avatarsCollection = await getObject(actorObj.streams.avatars);
+    }
+    // check if the collection is not paginated
+    items = avatarsCollection.orderedItems;
+    if (!items && avatarsCollection.first) {
+      // otherwise get page
+      collectionPage = await getObject(page || avatarsCollection.first);
+      items = collectionPage.orderedItems;
+      hubsResult.meta.next_cursor = collectionPage.next;
+    }
+    items.forEach(createActivity => {
+      const avatar = createActivity.object;
+      const avatarGltfUrl = getUrlFromAvatar(avatar);
+      // cache results for lookup by url when donned
+      myAvatars[avatarGltfUrl] = avatar;
+      // form object for Hubs MediaBrowser
+      let preview = Array.isArray(avatar.icon) ? avatar.icon[0] : avatar.icon;
+      // if link/image object instead of direct link
+      if (typeof preview === "object") {
+        preview = preview.href || preview.url;
+      }
+      hubsResult.entries.push({
+        type: "avatar",
+        name: avatar.name,
+        // id used by hubs to set the avatar, put model url here
+        id: avatarGltfUrl,
+        images: {
+          preview: {
+            // width/height ignored for avatar media
+            url: preview
+          }
+        },
+        // the url displayed on hover is the immers link
+        url: avatar.id
+      });
+    });
+  } catch (err) {
+    console.error("Cannot fetch avatar collection", err);
+  }
+  return hubsResult;
+}
+
 export async function getFriends(actorObj) {
   const response = await window.fetch(`${actorObj.id}/friends`, {
     headers: {
-      Accept: "application/activity+json",
+      Accept: jsonldMime,
       Authorization: `Bearer ${token}`
     }
   });
@@ -236,7 +306,7 @@ export async function initialize(store, scene, remountUI) {
   hubScene = scene;
   localPlayer = document.getElementById("avatar-rig");
   // immers profile
-  const actorObj = await authPromise;
+  actorObj = await authPromise;
   const initialAvi = store.state.profile.avatarId;
   store.update({
     profile: {
@@ -307,11 +377,11 @@ export async function initialize(store, scene, remountUI) {
   scene.addEventListener("avatar_updated", async () => {
     const profile = store.state.profile;
     // const avatar = await fetchAvatar(profile.avatarId);
-    const created = await createAvatar(actorObj, profile.avatarId);
+    const avatar = myAvatars[profile.avatarId] || (await createAvatar(actorObj, profile.avatarId)).object;
     updateProfile(actorObj, {
       name: profile.displayName,
-      avatar: created.object,
-      icon: created.object.icon
+      avatar,
+      icon: avatar.icon
     })
       .then(() => {
         store.update({


### PR DESCRIPTION
Co-requisite:  immers-space/immers#17

## Building avatar collection

* On selecting a new avatar (either form GUI or from in-scene avatar links):
  * Record it in immers by publishing a 'Create' activity with the avatar metadata in a 'Model' object
  * Add it to the user's history/avatar collection by publishing an 'Add' activity 
  * Set it as the current avatar on their immers profile by publishing an 'Update' to the actor's 'avatar' property. Also try setting the actor 'icon' to the avatar preview image - I think this should make your current avatar viewable via Mastodon and other fediverse app clients when your profile is searched
* Also update avatar retrieval to match new structure

## Viewing avatar collection
* Hijack the My Avatars tab of the avatar search UI and inject your immers space avatar collection, complete with pagination