### PR TITLE
Skip unnecessary profile updates

### DIFF
--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -350,7 +350,7 @@ export async function initialize(store, scene, remountUI) {
       leave: {
         type: "Leave",
         actor: actorObj.id,
-        target: window.location.href,
+        target: place,
         to: actorObj.followers
       }
     });

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -308,10 +308,13 @@ export async function initialize(store, scene, remountUI) {
   // immers profile
   actorObj = await authPromise;
   const initialAvi = store.state.profile.avatarId;
+  const actorAvi = getAvatarFromActor(actorObj);
+  // cache current avatar so doesn't get recreated during a profile update
+  myAvatars[actorAvi] = Array.isArray(actorObj.avatar) ? actorObj.avatar[0] : actorObj.avatar;
   store.update({
     profile: {
       id: actorObj.id,
-      avatarId: getAvatarFromActor(actorObj) || initialAvi,
+      avatarId: actorAvi || initialAvi,
       displayName: actorObj.name,
       handle: `${actorObj.preferredUsername}[${new URL(homeImmer).host}]`,
       inbox: actorObj.inbox,
@@ -376,21 +379,24 @@ export async function initialize(store, scene, remountUI) {
 
   scene.addEventListener("avatar_updated", async () => {
     const profile = store.state.profile;
-    // const avatar = await fetchAvatar(profile.avatarId);
-    const avatar = myAvatars[profile.avatarId] || (await createAvatar(actorObj, profile.avatarId)).object;
-    updateProfile(actorObj, {
-      name: profile.displayName,
-      avatar,
-      icon: avatar.icon
-    })
-      .then(() => {
-        store.update({
-          activity: {
-            hasChangedName: true
-          }
-        });
-      })
-      .catch(err => console.error("Error updating profile:", err.message));
+    const update = {};
+    if (profile.displayName !== actorObj.name) {
+      update.name = profile.displayName;
+    }
+    if (getAvatarFromActor(actorObj) !== profile.avatarId) {
+      update.avatar = myAvatars[profile.avatarId] || (await createAvatar(actorObj, profile.avatarId)).object;
+      update.icon = update.avatar.icon;
+    }
+    // only publish update if something changed
+    if (Object.keys(update).length) {
+      await updateProfile(actorObj, update).catch(err => console.error("Error updating profile:", err.message));
+    }
+    // disable the first-time entry name & avatar prompt
+    store.update({
+      activity: {
+        hasChangedName: true
+      }
+    });
   });
 
   // entity interactions


### PR DESCRIPTION
Fixes #9 

Also fixes an minor issue that Leave activities used to signal exiting an immer (putting you in offline status in friends lists) weren't correctly specifying the place you had left