### PR TITLE
Federated chat

### DIFF
--- a/src/hub.js
+++ b/src/hub.js
@@ -1554,5 +1554,5 @@ document.addEventListener("DOMContentLoaded", async () => {
   authChannel.setSocket(socket);
   linkChannel.setSocket(socket);
 
-  immers.initialize(store, scene, remountUI);
+  immers.initialize(store, scene, remountUI, messageDispatch);
 });

--- a/src/react-components/room/ChatSidebar.js
+++ b/src/react-components/room/ChatSidebar.js
@@ -246,7 +246,7 @@ MessageBubble.propTypes = {
   children: PropTypes.node
 };
 
-function getMessageComponent(message) {
+export function getMessageComponent(message) {
   switch (message.type) {
     case "chat": {
       const { formattedBody, monospace, emoji } = formatMessageBody(message.body);

--- a/src/react-components/room/ChatSidebarContainer.js
+++ b/src/react-components/room/ChatSidebarContainer.js
@@ -61,6 +61,10 @@ function processChatMessage(messageGroups, newMessage) {
     });
     return newMessageGroups;
   }
+  // local chat is ignored in favor of immers feed which includes it
+  if (!sent) {
+    return messageGroups;
+  }
   if (shouldCreateNewMessageGroup(messageGroups, newMessage, now)) {
     return [
       ...messageGroups,

--- a/src/react-components/room/ChatSidebarContainer.js
+++ b/src/react-components/room/ChatSidebarContainer.js
@@ -15,7 +15,7 @@ import { useMaintainScrollPosition } from "../misc/useMaintainScrollPosition";
 import { spawnChatMessage } from "../chat-message";
 import { discordBridgesForPresences } from "../../utils/phoenix-utils";
 import { useIntl } from "react-intl";
-import { ImmerChatMessage, ImmerMoreHistoryButton } from "./ImmersReact";
+import { ImmersChatMessage, ImmersMoreHistoryButton } from "./ImmersReact";
 
 const ChatContext = createContext({ messageGroups: [], sendMessage: () => {} });
 
@@ -276,12 +276,12 @@ export function ChatSidebarContainer({ scene, canSpawnMessages, presences, occup
   return (
     <ChatSidebar onClose={onClose}>
       <ChatMessageList ref={listRef} onScroll={onScrollList}>
-        <ImmerMoreHistoryButton />
+        <ImmersMoreHistoryButton />
         {messageGroups.map(({ id, systemMessage, isImmersFeed, ...rest }) => {
           if (systemMessage) {
             return <SystemMessage key={id} {...rest} />;
           } else if (isImmersFeed) {
-            return <ImmerChatMessage key={id} {...rest} />;
+            return <ImmersChatMessage key={id} {...rest} />;
           } else {
             return <ChatMessageGroup key={id} {...rest} />;
           }

--- a/src/react-components/room/ChatSidebarContainer.js
+++ b/src/react-components/room/ChatSidebarContainer.js
@@ -112,6 +112,7 @@ function updateMessageGroups(messageGroups, newMessage) {
     case "image":
     case "photo":
     case "video":
+    case "activity":
       return processChatMessage(messageGroups, newMessage);
     default:
       return messageGroups;

--- a/src/react-components/room/ChatSidebarContainer.js
+++ b/src/react-components/room/ChatSidebarContainer.js
@@ -50,6 +50,7 @@ function processChatMessage(messageGroups, newMessage) {
     newMessageGroups.splice(i === -1 ? newMessageGroups.length : i, 0, {
       id: uniqueMessageId++,
       isImmersFeed: messageProps.isImmersFeed,
+      isFriend: messageProps.isFriend,
       timestamp: messageProps.timestamp,
       sent: sent,
       sender: name,

--- a/src/react-components/room/ChatSidebarContainer.js
+++ b/src/react-components/room/ChatSidebarContainer.js
@@ -47,7 +47,7 @@ function processChatMessage(messageGroups, newMessage) {
     // insert according to timestamp
     const newMessageGroups = messageGroups.slice();
     const i = newMessageGroups.findIndex(group => messageProps.timestamp < group.timestamp);
-    newMessageGroups.splice(i === -1 ? 0 : i, 0, {
+    newMessageGroups.splice(i === -1 ? newMessageGroups.length : i, 0, {
       id: uniqueMessageId++,
       isImmersFeed: messageProps.isImmersFeed,
       timestamp: messageProps.timestamp,

--- a/src/react-components/room/ChatSidebarContainer.js
+++ b/src/react-components/room/ChatSidebarContainer.js
@@ -51,7 +51,7 @@ function processChatMessage(messageGroups, newMessage) {
       id: uniqueMessageId++,
       isImmersFeed: messageProps.isImmersFeed,
       timestamp: messageProps.timestamp,
-      sent: false,
+      sent: sent,
       sender: name,
       icon: messageProps.icon,
       senderSessionId: sessionId,

--- a/src/react-components/room/ChatSidebarContainer.js
+++ b/src/react-components/room/ChatSidebarContainer.js
@@ -15,7 +15,7 @@ import { useMaintainScrollPosition } from "../misc/useMaintainScrollPosition";
 import { spawnChatMessage } from "../chat-message";
 import { discordBridgesForPresences } from "../../utils/phoenix-utils";
 import { useIntl } from "react-intl";
-import { ImmerChatMessage } from "./ImmersReact";
+import { ImmerChatMessage, ImmerMoreHistoryButton } from "./ImmersReact";
 
 const ChatContext = createContext({ messageGroups: [], sendMessage: () => {} });
 
@@ -274,6 +274,7 @@ export function ChatSidebarContainer({ scene, canSpawnMessages, presences, occup
   return (
     <ChatSidebar onClose={onClose}>
       <ChatMessageList ref={listRef} onScroll={onScrollList}>
+        <ImmerMoreHistoryButton />
         {messageGroups.map(({ id, systemMessage, isImmersFeed, ...rest }) => {
           if (systemMessage) {
             return <SystemMessage key={id} {...rest} />;

--- a/src/react-components/room/ImmersReact.js
+++ b/src/react-components/room/ImmersReact.js
@@ -1,0 +1,67 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import { getMessageComponent } from "./ChatSidebar";
+import chatStyles from "./ChatSidebar.scss";
+import styles from "./ImmersReact.scss";
+import { FormattedRelativeTime } from "react-intl";
+import { proxiedUrlFor } from "../../utils/media-url-utils";
+import immersLogo from "../../assets/images/immers_logo.png";
+
+export function ImmerLink({ place }) {
+  if (!place) {
+    return;
+  }
+  let placeUrl = place.url;
+  // inject user handle into desintation url so they don't have to type it
+  try {
+    const url = new URL(placeUrl);
+    const search = new URLSearchParams(url.search);
+    search.set("me", window.APP.store.state.profile.handle);
+    url.search = search.toString();
+    placeUrl = url.toString();
+  } catch (ignore) {
+    /* if fail, leave original url unchanged */
+  }
+  return <a href={placeUrl}>{place.name ?? "unkown"}</a>;
+}
+
+ImmerLink.propTypes = {
+  place: PropTypes.object
+};
+
+export function ImmerChatMessage({ sent, sender, timestamp, icon, immer, context, messages }) {
+  return (
+    <li className={classNames(chatStyles.messageGroup, { [chatStyles.sent]: sent })}>
+      <p className={classNames(chatStyles.messageGroupLabel, styles.immerChatLabel)}>
+        <ImmerImageIcon src={immersLogo} />
+        {icon && <ImmerImageIcon src={icon} />}
+        {sender}
+        <span className={styles.immerName}>[{immer}]</span>&nbsp;|&nbsp;<ImmerLink place={context} />&nbsp;|{" "}
+        <FormattedRelativeTime updateIntervalInSeconds={10} value={(timestamp - Date.now()) / 1000} />
+      </p>
+      <ul className={chatStyles.messageGroupMessages}>{messages.map(message => getMessageComponent(message))}</ul>
+    </li>
+  );
+}
+
+ImmerChatMessage.propTypes = {
+  sent: PropTypes.bool,
+  sender: PropTypes.string,
+  timestamp: PropTypes.any,
+  messages: PropTypes.array,
+  immer: PropTypes.string,
+  icon: PropTypes.string,
+  context: PropTypes.object
+};
+
+export function ImmerImageIcon({ src }) {
+  return (
+    <span className={styles.imageIconWrapper}>
+      {src && <img className={styles.imageIcon} src={proxiedUrlFor(src)} />}
+    </span>
+  );
+}
+ImmerImageIcon.propTypes = {
+  src: PropTypes.string
+};

--- a/src/react-components/room/ImmersReact.js
+++ b/src/react-components/room/ImmersReact.js
@@ -51,7 +51,7 @@ export function ImmerChatMessage({ sent, sender, timestamp, isFriend, icon, imme
   return (
     <li className={classNames(chatStyles.messageGroup, { [chatStyles.sent]: sent })}>
       <p className={classNames(chatStyles.messageGroupLabel, styles.immerChatLabel)}>
-        {isFriend && <ImmerImageIcon src={immersLogo} />}
+        {isFriend && <ImmersFriendIcon />}
         {icon && <ImmerImageIcon src={icon} />}
         {sender}
         <span className={styles.immerName}>[{immer}]</span>&nbsp;|&nbsp;<ImmerLink place={context} />&nbsp;|{" "}
@@ -73,16 +73,21 @@ ImmerChatMessage.propTypes = {
   context: PropTypes.object
 };
 
-export function ImmerImageIcon({ src }) {
+export function ImmerImageIcon({ src, title }) {
   return (
     <span className={styles.imageIconWrapper}>
-      {src && <img className={styles.imageIcon} src={proxiedUrlFor(src)} />}
+      {src && <img className={styles.imageIcon} src={proxiedUrlFor(src)} title={title} />}
     </span>
   );
 }
 ImmerImageIcon.propTypes = {
-  src: PropTypes.string
+  src: PropTypes.string,
+  title: PropTypes.string
 };
+
+export function ImmersFriendIcon() {
+  return <ImmerImageIcon src={immersLogo} title={"Immers Space Friend"} />;
+}
 
 export function ImmerMoreHistoryButton() {
   const [isLoading, setIsLoading] = useState(false);

--- a/src/react-components/room/ImmersReact.js
+++ b/src/react-components/room/ImmersReact.js
@@ -16,21 +16,28 @@ export function ImmerLink({ place }) {
   // inject user handle into desintation url so they don't have to type it
   try {
     const url = new URL(placeUrl);
-    const search = new URLSearchParams(url.search);
-    search.set("me", window.APP.store.state.profile.handle);
-    url.search = search.toString();
-    placeUrl = url.toString();
+    if (
+      `${url.host}${url.pathname}${url.search}` ===
+      `${window.location.host}${window.location.pathname}${window.location.search}`
+    ) {
+      placeUrl = null;
+    } else {
+      const search = new URLSearchParams(url.search);
+      search.set("me", window.APP.store.state.profile.handle);
+      url.search = search.toString();
+      placeUrl = url.toString();
+    }
   } catch (ignore) {
     /* if fail, leave original url unchanged */
   }
-  return <a href={placeUrl}>{place.name ?? "unkown"}</a>;
+  return placeUrl ? <a href={placeUrl}>{place.name ?? "unkown"}</a> : "here";
 }
 
 ImmerLink.propTypes = {
   place: PropTypes.object
 };
 
-export function ImmerChatMessage({ sent, sender, timestamp, icon, immer, context, messages }) {
+export function ImmerChatMessage({ sent, sender, timestamp, isFriend, icon, immer, context, messages }) {
   if (messages[0].type === "activity") {
     return (
       <li className={classNames(chatStyles.messageGroup, { [chatStyles.sent]: sent })}>
@@ -44,7 +51,7 @@ export function ImmerChatMessage({ sent, sender, timestamp, icon, immer, context
   return (
     <li className={classNames(chatStyles.messageGroup, { [chatStyles.sent]: sent })}>
       <p className={classNames(chatStyles.messageGroupLabel, styles.immerChatLabel)}>
-        <ImmerImageIcon src={immersLogo} />
+        {isFriend && <ImmerImageIcon src={immersLogo} />}
         {icon && <ImmerImageIcon src={icon} />}
         {sender}
         <span className={styles.immerName}>[{immer}]</span>&nbsp;|&nbsp;<ImmerLink place={context} />&nbsp;|{" "}
@@ -62,6 +69,7 @@ ImmerChatMessage.propTypes = {
   messages: PropTypes.array,
   immer: PropTypes.string,
   icon: PropTypes.string,
+  isFriend: PropTypes.bool,
   context: PropTypes.object
 };
 

--- a/src/react-components/room/ImmersReact.js
+++ b/src/react-components/room/ImmersReact.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import { getMessageComponent } from "./ChatSidebar";
@@ -65,3 +65,37 @@ export function ImmerImageIcon({ src }) {
 ImmerImageIcon.propTypes = {
   src: PropTypes.string
 };
+
+export function ImmerMoreHistoryButton() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  useEffect(
+    () => {
+      const onMoreHistory = evt => {
+        setIsLoading(false);
+        setHasMore(evt.detail);
+      };
+      window.addEventListener("immers-more-history-loaded", onMoreHistory);
+      return () => window.removeEventListener("immers-more-history-loaded", onMoreHistory);
+    },
+    [setIsLoading, setHasMore]
+  );
+  const handleClick = evt => {
+    evt.preventDefault();
+    setIsLoading(true);
+    window.dispatchEvent(new CustomEvent("immers-load-more-history"));
+  };
+  return (
+    hasMore && (
+      <div className={styles.historyButton}>
+        {isLoading ? (
+          <span>Loading...</span>
+        ) : (
+          <a onClick={handleClick} href="#">
+            Load more
+          </a>
+        )}
+      </div>
+    )
+  );
+}

--- a/src/react-components/room/ImmersReact.js
+++ b/src/react-components/room/ImmersReact.js
@@ -37,7 +37,7 @@ ImmerLink.propTypes = {
   place: PropTypes.object
 };
 
-export function ImmerChatMessage({ sent, sender, timestamp, isFriend, icon, immer, context, messages }) {
+export function ImmersChatMessage({ sent, sender, timestamp, isFriend, icon, immer, context, messages }) {
   if (messages[0].type === "activity") {
     return (
       <li className={classNames(chatStyles.messageGroup, { [chatStyles.sent]: sent })}>
@@ -52,7 +52,7 @@ export function ImmerChatMessage({ sent, sender, timestamp, isFriend, icon, imme
     <li className={classNames(chatStyles.messageGroup, { [chatStyles.sent]: sent })}>
       <p className={classNames(chatStyles.messageGroupLabel, styles.immerChatLabel)}>
         {isFriend && <ImmersFriendIcon />}
-        {icon && <ImmerImageIcon src={icon} />}
+        {icon && <ImmersImageIcon src={icon} />}
         {sender}
         <span className={styles.immerName}>[{immer}]</span>&nbsp;|&nbsp;<ImmerLink place={context} />&nbsp;|{" "}
         <FormattedRelativeTime updateIntervalInSeconds={10} value={(timestamp - Date.now()) / 1000} />
@@ -62,7 +62,7 @@ export function ImmerChatMessage({ sent, sender, timestamp, isFriend, icon, imme
   );
 }
 
-ImmerChatMessage.propTypes = {
+ImmersChatMessage.propTypes = {
   sent: PropTypes.bool,
   sender: PropTypes.string,
   timestamp: PropTypes.any,
@@ -73,23 +73,23 @@ ImmerChatMessage.propTypes = {
   context: PropTypes.object
 };
 
-export function ImmerImageIcon({ src, title }) {
+export function ImmersImageIcon({ src, title }) {
   return (
     <span className={styles.imageIconWrapper}>
       {src && <img className={styles.imageIcon} src={proxiedUrlFor(src)} title={title} />}
     </span>
   );
 }
-ImmerImageIcon.propTypes = {
+ImmersImageIcon.propTypes = {
   src: PropTypes.string,
   title: PropTypes.string
 };
 
 export function ImmersFriendIcon() {
-  return <ImmerImageIcon src={immersLogo} title={"Immers Space Friend"} />;
+  return <ImmersImageIcon src={immersLogo} title={"Immers Space Friend"} />;
 }
 
-export function ImmerMoreHistoryButton() {
+export function ImmersMoreHistoryButton() {
   const [isLoading, setIsLoading] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   useEffect(

--- a/src/react-components/room/ImmersReact.js
+++ b/src/react-components/room/ImmersReact.js
@@ -52,7 +52,7 @@ export function ImmersChatMessage({ sent, sender, timestamp, isFriend, icon, imm
     <li className={classNames(chatStyles.messageGroup, { [chatStyles.sent]: sent })}>
       <p className={classNames(chatStyles.messageGroupLabel, styles.immerChatLabel)}>
         {isFriend && <ImmersFriendIcon />}
-        {icon && <ImmersImageIcon src={icon} />}
+        {icon && <ImmersAvatarIcon avi={icon} />}
         {sender}
         <span className={styles.immerName}>[{immer}]</span>&nbsp;|&nbsp;<ImmerLink place={context} />&nbsp;|{" "}
         <FormattedRelativeTime updateIntervalInSeconds={10} value={(timestamp - Date.now()) / 1000} />
@@ -88,6 +88,15 @@ ImmersImageIcon.propTypes = {
 export function ImmersFriendIcon() {
   return <ImmersImageIcon src={immersLogo} title={"Immers Space Friend"} />;
 }
+
+export function ImmersAvatarIcon({ avi }) {
+  // support both Image objects & direct url
+  const src = avi.url || avi;
+  return <ImmersImageIcon src={src} />;
+}
+ImmersAvatarIcon.propTypes = {
+  avi: PropTypes.any
+};
 
 export function ImmersMoreHistoryButton() {
   const [isLoading, setIsLoading] = useState(false);

--- a/src/react-components/room/ImmersReact.js
+++ b/src/react-components/room/ImmersReact.js
@@ -31,6 +31,16 @@ ImmerLink.propTypes = {
 };
 
 export function ImmerChatMessage({ sent, sender, timestamp, icon, immer, context, messages }) {
+  if (messages[0].type === "activity") {
+    return (
+      <li className={classNames(chatStyles.messageGroup, { [chatStyles.sent]: sent })}>
+        <p className={classNames(chatStyles.messageGroupLabel, styles.immerChatLabel)}>
+          {messages[0].body} |{" "}
+          <FormattedRelativeTime updateIntervalInSeconds={10} value={(timestamp - Date.now()) / 1000} />
+        </p>
+      </li>
+    );
+  }
   return (
     <li className={classNames(chatStyles.messageGroup, { [chatStyles.sent]: sent })}>
       <p className={classNames(chatStyles.messageGroupLabel, styles.immerChatLabel)}>

--- a/src/react-components/room/ImmersReact.scss
+++ b/src/react-components/room/ImmersReact.scss
@@ -1,0 +1,19 @@
+@use "../styles/theme.scss";
+
+:local(.image-icon-wrapper) {
+  width: 20px;
+  height: 20px;
+  overflow: hidden;
+}
+
+:local(.image-icon) {
+  width: 20px;
+}
+
+:local(.immer-name) {
+  color: theme.$grey;
+}
+
+:local(.immer-chat-label) {
+  align-items: center;
+}

--- a/src/react-components/room/ImmersReact.scss
+++ b/src/react-components/room/ImmersReact.scss
@@ -17,3 +17,27 @@
 :local(.immer-chat-label) {
   align-items: center;
 }
+
+:local(.sent) {
+  :local(.message-group-label) {
+    align-self: flex-end;
+  }
+
+  :local(.message-bubble) {
+    background-color: theme.$blue;
+    color: theme.$white;
+    align-self: flex-end;
+
+    a {
+      color: theme.$white;
+
+      &:hover {
+        color: theme.$white-hover;
+      }
+
+      &:active {
+        color: theme.$white-pressed;
+      }
+    }
+  }
+}

--- a/src/react-components/room/ImmersReact.scss
+++ b/src/react-components/room/ImmersReact.scss
@@ -41,3 +41,9 @@
     }
   }
 }
+
+:local(.history-button) {
+  text-align: center;
+  padding-top: 5px;
+  font-size: theme.$font-size-sm;
+}

--- a/src/react-components/room/PeopleSidebar.js
+++ b/src/react-components/room/PeopleSidebar.js
@@ -16,6 +16,7 @@ import immersLogo from "../../assets/images/immers_logo.png";
 import { List, ButtonListItem } from "../layout/List";
 import { FormattedMessage, useIntl } from "react-intl";
 import { proxiedUrlFor } from "../../utils/media-url-utils";
+import { ImmerLink } from "./ImmersReact";
 
 function getDeviceLabel(ctx, intl) {
   if (ctx) {
@@ -86,20 +87,9 @@ function getLocationMessage(activity, myHandle, intl) {
   switch (activity.type) {
     case "Arrive": {
       const onlineMsg = intl.formatMessage({ id: "people-sidebar.immers.online", defaultMessage: "Online at" });
-      let placeUrl = activity.target?.url;
-      // inject user handle into desintation url so they don't have to type it
-      try {
-        const url = new URL(placeUrl);
-        const search = new URLSearchParams(url.search);
-        search.set("me", myHandle);
-        url.search = search.toString();
-        placeUrl = url.toString();
-      } catch (ignore) {
-        /* if fail, leave original url unchanged */
-      }
       return (
         <span>
-          {onlineMsg} <a href={placeUrl}>{activity.target?.name ?? "unkown"}</a>
+          {onlineMsg} <ImmerLink place={activity.target} />
         </span>
       );
     }

--- a/src/react-components/room/PeopleSidebar.js
+++ b/src/react-components/room/PeopleSidebar.js
@@ -14,7 +14,7 @@ import { ReactComponent as VolumeHighIcon } from "../icons/VolumeHigh.svg";
 import { ReactComponent as VolumeMutedIcon } from "../icons/VolumeMuted.svg";
 import { List, ButtonListItem } from "../layout/List";
 import { FormattedMessage, useIntl } from "react-intl";
-import { ImmerLink, ImmerImageIcon, ImmersFriendIcon } from "./ImmersReact";
+import { ImmerLink, ImmersImageIcon, ImmersFriendIcon } from "./ImmersReact";
 
 function getDeviceLabel(ctx, intl) {
   if (ctx) {
@@ -146,7 +146,7 @@ export function PeopleSidebar({ people, onSelectPerson, onClose, showMuteAll, on
               {person.friendStatus && <ImmersFriendIcon />}
               {!person.remote && <DeviceIcon title={getDeviceLabel(person.context, intl)} />}
               {person.remote ? (
-                <ImmerImageIcon src={person.friendStatus.actor.icon} />
+                <ImmersImageIcon src={person.friendStatus.actor.icon} />
               ) : (
                 !person.context.discord &&
                 !person.remote &&

--- a/src/react-components/room/PeopleSidebar.js
+++ b/src/react-components/room/PeopleSidebar.js
@@ -12,11 +12,9 @@ import { ReactComponent as VRIcon } from "../icons/VR.svg";
 import { ReactComponent as VolumeOffIcon } from "../icons/VolumeOff.svg";
 import { ReactComponent as VolumeHighIcon } from "../icons/VolumeHigh.svg";
 import { ReactComponent as VolumeMutedIcon } from "../icons/VolumeMuted.svg";
-import immersLogo from "../../assets/images/immers_logo.png";
 import { List, ButtonListItem } from "../layout/List";
 import { FormattedMessage, useIntl } from "react-intl";
-import { proxiedUrlFor } from "../../utils/media-url-utils";
-import { ImmerLink } from "./ImmersReact";
+import { ImmerLink, ImmerImageIcon, ImmersFriendIcon } from "./ImmersReact";
 
 function getDeviceLabel(ctx, intl) {
   if (ctx) {
@@ -100,14 +98,6 @@ function getLocationMessage(activity, myHandle, intl) {
   }
 }
 
-function imageIcon(src) {
-  return (
-    <span className={styles.imageIconWrapper}>
-      {src && <img className={styles.imageIcon} src={proxiedUrlFor(src)} />}
-    </span>
-  );
-}
-
 function getPersonName(person, intl) {
   const you = intl.formatMessage({
     id: "people-sidebar.person-name.you",
@@ -153,12 +143,15 @@ export function PeopleSidebar({ people, onSelectPerson, onClose, showMuteAll, on
               onClick={e => onSelectPerson(person, e)}
               disabled={person.remote}
             >
-              {person.remote ? imageIcon(immersLogo) : <DeviceIcon title={getDeviceLabel(person.context, intl)} />}
-              {person.remote
-                ? imageIcon(person.friendStatus.actor.icon)
-                : !person.context.discord &&
-                  !person.remote &&
-                  VoiceIcon && <VoiceIcon title={getVoiceLabel(person.micPresence, intl)} />}
+              {person.friendStatus && <ImmersFriendIcon />}
+              {!person.remote && <DeviceIcon title={getDeviceLabel(person.context, intl)} />}
+              {person.remote ? (
+                <ImmerImageIcon src={person.friendStatus.actor.icon} />
+              ) : (
+                !person.context.discord &&
+                !person.remote &&
+                VoiceIcon && <VoiceIcon title={getVoiceLabel(person.micPresence, intl)} />
+              )}
               <p>{getPersonName(person, intl)}</p>
               {person.roles.owner && (
                 <StarIcon

--- a/src/react-components/room/PeopleSidebar.js
+++ b/src/react-components/room/PeopleSidebar.js
@@ -14,7 +14,7 @@ import { ReactComponent as VolumeHighIcon } from "../icons/VolumeHigh.svg";
 import { ReactComponent as VolumeMutedIcon } from "../icons/VolumeMuted.svg";
 import { List, ButtonListItem } from "../layout/List";
 import { FormattedMessage, useIntl } from "react-intl";
-import { ImmerLink, ImmersImageIcon, ImmersFriendIcon } from "./ImmersReact";
+import { ImmerLink, ImmersAvatarIcon, ImmersFriendIcon } from "./ImmersReact";
 
 function getDeviceLabel(ctx, intl) {
   if (ctx) {
@@ -146,7 +146,7 @@ export function PeopleSidebar({ people, onSelectPerson, onClose, showMuteAll, on
               {person.friendStatus && <ImmersFriendIcon />}
               {!person.remote && <DeviceIcon title={getDeviceLabel(person.context, intl)} />}
               {person.remote ? (
-                <ImmersImageIcon src={person.friendStatus.actor.icon} />
+                <ImmersAvatarIcon avi={person.friendStatus.actor.icon} />
               ) : (
                 !person.context.discord &&
                 !person.remote &&

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -4,7 +4,7 @@ import { fetchAvatar } from "./avatar-utils";
 import { setupMonetization } from "./immers/monetization";
 import Activities from "./immers/activities";
 const localImmer = configs.IMMERS_SERVER;
-console.log("immers.space client v0.4.1");
+console.log("immers.space client v0.5.0");
 const jsonldMime = "application/activity+json";
 // avoid race between auth and initialize code
 let resolveAuth;
@@ -390,6 +390,14 @@ export async function initialize(store, scene, remountUI, messageDispatch) {
     });
   };
   updateFeed();
+  immerSocket.on("inbox-update", activity => {
+    activity = JSON.parse(activity);
+    if (activity.type === "Create") {
+      const detail = Activities.ActivityAsChat(activity);
+      messageDispatch.dispatchEvent(new CustomEvent("message", { detail }));
+    }
+  });
+
   scene.addEventListener("avatar_updated", async () => {
     const profile = store.state.profile;
     const update = {};

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -445,18 +445,21 @@ export async function initialize(store, scene, remountUI, messageDispatch) {
     if (!message.sent) {
       return;
     }
+    const localAudience = Object.values(window.APP.hubChannel.presence.state)
+      .map(presence => presence.metas[presence.metas.length - 1]?.profile.id)
+      .filter(id => id && id !== actorObj.id);
     // send activity
     let task;
     switch (message.type) {
       case "chat":
-        task = activities.note(message.body, true, null);
+        task = activities.note(message.body, localAudience, true, null);
         break;
       case "image":
       case "photo":
-        task = activities.image(message.body.src, true, null);
+        task = activities.image(message.body.src, localAudience, true, null);
         break;
       case "video":
-        task = activities.video(message.body.src, true, null);
+        task = activities.video(message.body.src, localAudience, true, null);
         break;
       default:
         console.log("Chat message not shared", message);

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -390,6 +390,13 @@ export async function initialize(store, scene, remountUI, messageDispatch) {
     });
   };
   updateFeed();
+  const updateOutboxFeed = async () => {
+    const inboxItems = await activities.outboxAsChat();
+    inboxItems.forEach(detail => {
+      messageDispatch.dispatchEvent(new CustomEvent("message", { detail }));
+    });
+  };
+  updateOutboxFeed();
   immerSocket.on("inbox-update", activity => {
     activity = JSON.parse(activity);
     if (activity.type === "Create") {
@@ -442,7 +449,7 @@ export async function initialize(store, scene, remountUI, messageDispatch) {
   // chat integration
   messageDispatch.addEventListener("message", ({ detail: message }) => {
     // check if it was sent by me
-    if (!message.sent) {
+    if (!message.sent || message.isImmersFeed) {
       return;
     }
     const localAudience = Object.values(window.APP.hubChannel.presence.state)

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -443,6 +443,13 @@ export async function initialize(store, scene, remountUI, messageDispatch) {
       case "chat":
         task = activities.note(message.body, true, null);
         break;
+      case "image":
+      case "photo":
+        task = activities.image(message.body.src, true, null);
+        break;
+      case "video":
+        task = activities.video(message.body.src, true, null);
+        break;
       default:
         console.log("Chat message not shared", message);
     }

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -109,16 +109,8 @@ export function arrive(actorObj) {
     type: "Arrive",
     actor: actorObj.id,
     target: place,
-    to: actorObj.followers
-  });
-}
-
-export function leave(actorObj) {
-  return postActivity(actorObj.outbox, {
-    type: "Leave",
-    actor: actorObj.id,
-    target: place,
-    to: actorObj.followers
+    to: actorObj.followers,
+    summary: `${actorObj.name} arrived at ${place.name}.`
   });
 }
 
@@ -357,7 +349,8 @@ export async function initialize(store, scene, remountUI, messageDispatch) {
         type: "Leave",
         actor: actorObj.id,
         target: place,
-        to: actorObj.followers
+        to: actorObj.followers,
+        summary: `${actorObj.name} left ${place.name}.`
       }
     });
   });

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -129,7 +129,11 @@ export async function createAvatar(actorObj, hubsAvatarId) {
     generator: place
   };
   if (hubsAvatar.files.thumbnail) {
-    immersAvatar.icon = hubsAvatar.files.thumbnail;
+    immersAvatar.icon = {
+      type: "Image",
+      mediaType: "image/png",
+      url: hubsAvatar.files.thumbnail
+    };
   }
   if (hubsAvatar.attributions) {
     immersAvatar.attributedTo = Object.values(hubsAvatar.attributions).map(name => ({

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -361,6 +361,7 @@ export async function initialize(store, scene, remountUI, messageDispatch) {
     if (store.state.profile.id) {
       const profile = store.state.profile;
       friendsCol = await getFriends(profile);
+      activities.friends = friendsCol.orderedItems;
       remountUI({ friends: friendsCol.orderedItems, handle: profile.handle });
       // update follow button for new friends
       const players = window.APP.componentRegistry["player-info"];
@@ -393,7 +394,7 @@ export async function initialize(store, scene, remountUI, messageDispatch) {
   immerSocket.on("inbox-update", activity => {
     activity = JSON.parse(activity);
     if (activity.type === "Create") {
-      const detail = Activities.ActivityAsChat(activity);
+      const detail = activities.activityAsChat(activity);
       messageDispatch.dispatchEvent(new CustomEvent("message", { detail }));
     }
   });

--- a/src/utils/immers/activities.js
+++ b/src/utils/immers/activities.js
@@ -1,0 +1,90 @@
+export default class Activities {
+  static JSONLDMime = "application/activity+json";
+  static PublicAddress = "as:Public";
+  constructor(localImmer) {
+    this.localImmer = localImmer;
+    this.homeImmer = null;
+    this.token = null;
+    this.actor = null;
+    this.place = null;
+    this.nextInboxPage = null;
+  }
+
+  trustedIRI(IRI) {
+    return IRI.startsWith(this.localImmer) || IRI.startsWith(this.homeImmer);
+  }
+
+  async getObject(IRI) {
+    if (this.trustedIRI(IRI)) {
+      const headers = { Accept: Activities.JSONLDMime };
+      if (this.token) {
+        headers.Authorization = `Bearer ${this.token}`;
+      }
+      const result = await window.fetch(IRI, { headers });
+      if (!result.ok) {
+        throw new Error(`Object fetch error ${result.message}`);
+      }
+      return result.json();
+    } else {
+      throw new Error("Object fetch proxy not implemented");
+    }
+  }
+
+  async inbox() {
+    const col = await this.getObject(this.actor.inbox);
+    if (!col.orderedItems && col.first) {
+      return this.getObject(col.first);
+    }
+    return col;
+  }
+
+  async inboxAsChat() {
+    const inbox = await this.inbox();
+    if (!inbox.orderedItems) {
+      return [];
+    }
+    return inbox.orderedItems.filter(activity => activity.object?.content).map(activity => ({
+      isImmersFeed: true,
+      sent: false,
+      type: "chat",
+      body: activity.object.content,
+      context: activity.object.context,
+      timestamp: new Date(activity.published).getTime(),
+      name: activity.actor.name,
+      sessionId: activity.actor.id,
+      icon: activity.actor.icon,
+      immer: new URL(activity.actor.id).hostname
+    }));
+  }
+
+  postActivity(activity) {
+    if (!this.trustedIRI(this.actor.outbox)) {
+      throw new Error("Inavlid outbox address");
+    }
+    return window.fetch(this.actor.outbox, {
+      method: "POST",
+      headers: {
+        "Content-Type": Activities.JSONLDMime,
+        Authorization: `Bearer ${this.token}`
+      },
+      body: JSON.stringify(activity)
+    });
+  }
+
+  note(content, isPublic, summary) {
+    const obj = {
+      content,
+      type: "Note",
+      attributedTo: this.actor.id,
+      context: this.place,
+      to: [this.actor.followers]
+    };
+    if (summary) {
+      obj.summary = summary;
+    }
+    if (isPublic) {
+      obj.to.push(Activities.PublicAddress);
+    }
+    return this.postActivity(obj);
+  }
+}

--- a/src/utils/immers/activities.js
+++ b/src/utils/immers/activities.js
@@ -11,6 +11,7 @@ export default class Activities {
     this.nextOutboxPage = null;
     this.inboxStartDate = new Date();
     this.outboxStartDate = this.inboxStartDate;
+    this.friends = [];
   }
 
   trustedIRI(IRI) {
@@ -67,7 +68,7 @@ export default class Activities {
       return [];
     }
     this.inboxStartDate = new Date(inbox.orderedItems[inbox.orderedItems.length - 1].published);
-    return inbox.orderedItems.map(act => Activities.ActivityAsChat(act)).filter(message => message.body);
+    return inbox.orderedItems.map(act => this.activityAsChat(act)).filter(message => message.body);
   }
 
   async outboxAsChat() {
@@ -76,7 +77,7 @@ export default class Activities {
       return [];
     }
     this.outboxStartDate = new Date(outbox.orderedItems[outbox.orderedItems.length - 1].published);
-    return outbox.orderedItems.map(act => Activities.ActivityAsChat(act, true)).filter(message => message.body);
+    return outbox.orderedItems.map(act => this.activityAsChat(act, true)).filter(message => message.body);
   }
 
   async feedAsChat() {
@@ -162,9 +163,10 @@ export default class Activities {
     return this.postActivity(obj);
   }
 
-  static ActivityAsChat(activity, outbox = false) {
+  activityAsChat(activity, outbox = false) {
     const message = {
       isImmersFeed: true,
+      isFriend: this.friends.some(status => status.actor.id === activity.actor.id),
       sent: outbox,
       context: activity.object?.context,
       timestamp: new Date(activity.published).getTime(),

--- a/src/utils/immers/activities.js
+++ b/src/utils/immers/activities.js
@@ -43,35 +43,7 @@ export default class Activities {
     if (!inbox.orderedItems) {
       return [];
     }
-    return inbox.orderedItems.filter(activity => activity.type === "Create").map(activity => {
-      const message = {
-        isImmersFeed: true,
-        sent: false,
-        // type: "chat",
-        // body: activity.object.content,
-        context: activity.object.context,
-        timestamp: new Date(activity.published).getTime(),
-        name: activity.actor.name,
-        sessionId: activity.actor.id,
-        icon: activity.actor.icon,
-        immer: new URL(activity.actor.id).hostname
-      };
-      switch (activity.object.type) {
-        case "Note":
-          message.type = "chat";
-          message.body = activity.object.content;
-          break;
-        case "Image":
-          message.type = "photo";
-          message.body = { src: activity.object.url };
-          break;
-        case "Video":
-          message.type = "video";
-          message.body = { src: activity.object.url };
-          break;
-      }
-      return message;
-    });
+    return inbox.orderedItems.filter(activity => activity.type === "Create").map(Activities.ActivityAsChat);
   }
 
   postActivity(activity) {
@@ -135,5 +107,33 @@ export default class Activities {
       obj.to.push(Activities.PublicAddress);
     }
     return this.postActivity(obj);
+  }
+
+  static ActivityAsChat(activity) {
+    const message = {
+      isImmersFeed: true,
+      sent: false,
+      context: activity.object.context,
+      timestamp: new Date(activity.published).getTime(),
+      name: activity.actor.name,
+      sessionId: activity.actor.id,
+      icon: activity.actor.icon,
+      immer: new URL(activity.actor.id).hostname
+    };
+    switch (activity.object.type) {
+      case "Note":
+        message.type = "chat";
+        message.body = activity.object.content;
+        break;
+      case "Image":
+        message.type = "photo";
+        message.body = { src: activity.object.url };
+        break;
+      case "Video":
+        message.type = "video";
+        message.body = { src: activity.object.url };
+        break;
+    }
+    return message;
   }
 }

--- a/src/utils/immers/activities.js
+++ b/src/utils/immers/activities.js
@@ -43,18 +43,35 @@ export default class Activities {
     if (!inbox.orderedItems) {
       return [];
     }
-    return inbox.orderedItems.filter(activity => activity.object?.content).map(activity => ({
-      isImmersFeed: true,
-      sent: false,
-      type: "chat",
-      body: activity.object.content,
-      context: activity.object.context,
-      timestamp: new Date(activity.published).getTime(),
-      name: activity.actor.name,
-      sessionId: activity.actor.id,
-      icon: activity.actor.icon,
-      immer: new URL(activity.actor.id).hostname
-    }));
+    return inbox.orderedItems.filter(activity => activity.type === "Create").map(activity => {
+      const message = {
+        isImmersFeed: true,
+        sent: false,
+        // type: "chat",
+        // body: activity.object.content,
+        context: activity.object.context,
+        timestamp: new Date(activity.published).getTime(),
+        name: activity.actor.name,
+        sessionId: activity.actor.id,
+        icon: activity.actor.icon,
+        immer: new URL(activity.actor.id).hostname
+      };
+      switch (activity.object.type) {
+        case "Note":
+          message.type = "chat";
+          message.body = activity.object.content;
+          break;
+        case "Image":
+          message.type = "photo";
+          message.body = { src: activity.object.url };
+          break;
+        case "Video":
+          message.type = "video";
+          message.body = { src: activity.object.url };
+          break;
+      }
+      return message;
+    });
   }
 
   postActivity(activity) {
@@ -75,6 +92,38 @@ export default class Activities {
     const obj = {
       content,
       type: "Note",
+      attributedTo: this.actor.id,
+      context: this.place,
+      to: [this.actor.followers]
+    };
+    if (summary) {
+      obj.summary = summary;
+    }
+    if (isPublic) {
+      obj.to.push(Activities.PublicAddress);
+    }
+    return this.postActivity(obj);
+  }
+  image(url, isPublic, summary) {
+    const obj = {
+      url,
+      type: "Image",
+      attributedTo: this.actor.id,
+      context: this.place,
+      to: [this.actor.followers]
+    };
+    if (summary) {
+      obj.summary = summary;
+    }
+    if (isPublic) {
+      obj.to.push(Activities.PublicAddress);
+    }
+    return this.postActivity(obj);
+  }
+  video(url, isPublic, summary) {
+    const obj = {
+      url,
+      type: "Video",
       attributedTo: this.actor.id,
       context: this.place,
       to: [this.actor.followers]

--- a/src/utils/immers/activities.js
+++ b/src/utils/immers/activities.js
@@ -67,7 +67,7 @@ export default class Activities {
       return [];
     }
     this.inboxStartDate = new Date(inbox.orderedItems[inbox.orderedItems.length - 1].published);
-    return inbox.orderedItems.filter(activity => activity.type === "Create").map(act => Activities.ActivityAsChat(act));
+    return inbox.orderedItems.map(act => Activities.ActivityAsChat(act)).filter(message => message.body);
   }
 
   async outboxAsChat() {
@@ -76,9 +76,7 @@ export default class Activities {
       return [];
     }
     this.outboxStartDate = new Date(outbox.orderedItems[outbox.orderedItems.length - 1].published);
-    return outbox.orderedItems
-      .filter(activity => activity.type === "Create")
-      .map(act => Activities.ActivityAsChat(act, true));
+    return outbox.orderedItems.map(act => Activities.ActivityAsChat(act, true)).filter(message => message.body);
   }
 
   async feedAsChat() {
@@ -168,14 +166,14 @@ export default class Activities {
     const message = {
       isImmersFeed: true,
       sent: outbox,
-      context: activity.object.context,
+      context: activity.object?.context,
       timestamp: new Date(activity.published).getTime(),
       name: activity.actor.name,
       sessionId: activity.actor.id,
       icon: activity.actor.icon,
       immer: new URL(activity.actor.id).hostname
     };
-    switch (activity.object.type) {
+    switch (activity.object?.type) {
       case "Note":
         message.type = "chat";
         message.body = activity.object.content;
@@ -188,6 +186,11 @@ export default class Activities {
         message.type = "video";
         message.body = { src: activity.object.url };
         break;
+      default:
+        if (activity.summary) {
+          message.type = "activity";
+          message.body = activity.summary;
+        }
     }
     return message;
   }

--- a/src/utils/immers/activities.js
+++ b/src/utils/immers/activities.js
@@ -60,13 +60,13 @@ export default class Activities {
     });
   }
 
-  note(content, isPublic, summary) {
+  note(content, to, isPublic, summary) {
     const obj = {
       content,
       type: "Note",
       attributedTo: this.actor.id,
       context: this.place,
-      to: [this.actor.followers]
+      to: [this.actor.followers, ...to]
     };
     if (summary) {
       obj.summary = summary;
@@ -76,13 +76,14 @@ export default class Activities {
     }
     return this.postActivity(obj);
   }
-  image(url, isPublic, summary) {
+
+  image(url, to, isPublic, summary) {
     const obj = {
       url,
       type: "Image",
       attributedTo: this.actor.id,
       context: this.place,
-      to: [this.actor.followers]
+      to: [this.actor.followers, ...to]
     };
     if (summary) {
       obj.summary = summary;
@@ -92,13 +93,14 @@ export default class Activities {
     }
     return this.postActivity(obj);
   }
-  video(url, isPublic, summary) {
+
+  video(url, to, isPublic, summary) {
     const obj = {
       url,
       type: "Video",
       attributedTo: this.actor.id,
       context: this.place,
-      to: [this.actor.followers]
+      to: [this.actor.followers, ...to]
     };
     if (summary) {
       obj.summary = summary;


### PR DESCRIPTION
Requires immers server update: immers-space/immers#21

Connects local chat with the federated Immers Space network and converts the Hubs chat panel into a news feed. Chat messages and pictures/videos taken with the camera tool will now be shared with your social network (and hopefully will be viewable in other ActivityPub networks like Mastodon)

* [x] Capture outgoing chat messages and post to social network
  * [x] Text
  * [x] Image
  * [x] Video
* [x] Show news feed in chat panel
  * [x] Text
  * [x] Image
  * [x] Video
  * [x] "Show more" to fetch more history
  * [x] Streaming updates of new messages while in a room
  * [ ] ~~Post privacy setting (local, friends, or public)~~ (moved to #24 )
  * [x] Avoid showing duplicates when a friend in the same room posts
    * [x] Add everyone in room to post audience (friend or not)
    * [x] Hide local chat as all messages will come through Immers Space

Other changes:
* Show immers friend icon in people list for people in room who are friends and add a tooltip to explain the icon
* Change form of actor icon to object from direct link (trying to get profile icons to show in Mastodon), support old & new forms for display
* Added a summary description to Arrive/Leave activities to make them easier to display in chat - this will only apply going fowards. Older activities will not appear