### PR TITLE
clear state on load if invalid

### DIFF
--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -216,7 +216,8 @@ export default class Store extends EventTarget {
   constructor() {
     super();
 
-    if (localStorage.getItem(LOCAL_STORE_KEY) === null) {
+    const savedState = localStorage.getItem(LOCAL_STORE_KEY)
+    if (savedState === null || !validator.validate(JSON.parse(savedState), SCHEMA).valid) {
       localStorage.setItem(LOCAL_STORE_KEY, JSON.stringify({}));
     }
 


### PR DESCRIPTION
Fixes the blank page bug if you've got a saved state that doesn't validate due to switching around between hubs versions

Hubs didn't want this in upstream so we'll just add it here