### PR TITLE
News feed & chat integration - immers core code portion

### DIFF
--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -302,7 +302,7 @@ export async function auth(store) {
   }
 }
 
-export async function initialize(store, scene, remountUI, messageDispatch) {
+export async function initialize(store, scene, remountUI, messageDispatch, createInWorldLogMessage) {
   hubScene = scene;
   localPlayer = document.getElementById("avatar-rig");
   // immers profile
@@ -441,9 +441,12 @@ export async function initialize(store, scene, remountUI, messageDispatch) {
     // stream new activity while in room
     immerSocket.on("inbox-update", activity => {
       activity = JSON.parse(activity);
-      if (activity.type === "Create") {
-        const detail = activities.activityAsChat(activity);
-        messageDispatch.dispatchEvent(new CustomEvent("message", { detail }));
+      const message = activities.activityAsChat(activity);
+      if (message.body) {
+        messageDispatch.dispatchEvent(new CustomEvent("message", { detail: message }));
+        if (scene.is("vr-mode")) {
+          createInWorldLogMessage(message);
+        }
       }
     });
     // intercept outgoing messages and post to immers space feed

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -4,7 +4,7 @@ import { fetchAvatar } from "./avatar-utils";
 import { setupMonetization } from "./immers/monetization";
 import Activities from "./immers/activities";
 const localImmer = configs.IMMERS_SERVER;
-console.log("immers.space client v0.4.1");
+console.log("immers.space client v0.5.0");
 const jsonldMime = "application/activity+json";
 // avoid race between auth and initialize code
 let resolveAuth;

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -2,8 +2,9 @@ import io from "socket.io-client";
 import configs from "./configs";
 import { fetchAvatar } from "./avatar-utils";
 import { setupMonetization } from "./immers/monetization";
+import Activities from "./immers/activities";
 const localImmer = configs.IMMERS_SERVER;
-console.log("immers.space client v0.4.0");
+console.log("immers.space client v0.4.1");
 const jsonldMime = "application/activity+json";
 // avoid race between auth and initialize code
 let resolveAuth;
@@ -12,6 +13,7 @@ const authPromise = new Promise((resolve, reject) => {
   resolveAuth = resolve;
   rejectAuth = reject;
 });
+const activities = new Activities(localImmer);
 let homeImmer;
 let place;
 let token;
@@ -107,16 +109,8 @@ export function arrive(actorObj) {
     type: "Arrive",
     actor: actorObj.id,
     target: place,
-    to: actorObj.followers
-  });
-}
-
-export function leave(actorObj) {
-  return postActivity(actorObj.outbox, {
-    type: "Leave",
-    actor: actorObj.id,
-    target: place,
-    to: actorObj.followers
+    to: actorObj.followers,
+    summary: `${actorObj.name} arrived at ${place.name}.`
   });
 }
 
@@ -135,7 +129,11 @@ export async function createAvatar(actorObj, hubsAvatarId) {
     generator: place.id
   };
   if (hubsAvatar.files.thumbnail) {
-    immersAvatar.icon = hubsAvatar.files.thumbnail;
+    immersAvatar.icon = {
+      type: "Image",
+      mediaType: "image/png",
+      url: hubsAvatar.files.thumbnail
+    };
   }
   if (hubsAvatar.attributions) {
     immersAvatar.attributedTo = Object.values(hubsAvatar.attributions).map(name => ({
@@ -254,7 +252,7 @@ export async function auth(store) {
   }
   place = await getObject(`${localImmer}/o/immer`);
   place.url = hubUri; // include room id
-
+  activities.place = place;
   if (hashParams.has("access_token")) {
     // not safe to update store here, will be saved later in initialize()
     token = hashParams.get("access_token");
@@ -264,6 +262,8 @@ export async function auth(store) {
     token = store.state.credentials.immerToken;
     homeImmer = store.state.credentials.immerHome;
   }
+  activities.token = token;
+  activities.homeImmer = homeImmer;
 
   const redirectToAuth = () => {
     // send to token endpoint at local immer, it handles
@@ -302,11 +302,12 @@ export async function auth(store) {
   }
 }
 
-export async function initialize(store, scene, remountUI) {
+export async function initialize(store, scene, remountUI, messageDispatch) {
   hubScene = scene;
   localPlayer = document.getElementById("avatar-rig");
   // immers profile
   actorObj = await authPromise;
+  activities.actor = actorObj;
   const initialAvi = store.state.profile.avatarId;
   const actorAvi = getAvatarFromActor(actorObj);
   // cache current avatar so doesn't get recreated during a profile update
@@ -351,7 +352,8 @@ export async function initialize(store, scene, remountUI) {
         type: "Leave",
         actor: actorObj.id,
         target: place,
-        to: actorObj.followers
+        to: actorObj.followers,
+        summary: `${actorObj.name} left ${place.name}.`
       }
     });
   });
@@ -362,6 +364,7 @@ export async function initialize(store, scene, remountUI) {
     if (store.state.profile.id) {
       const profile = store.state.profile;
       friendsCol = await getFriends(profile);
+      activities.friends = friendsCol.orderedItems;
       remountUI({ friends: friendsCol.orderedItems, handle: profile.handle });
       // update follow button for new friends
       const players = window.APP.componentRegistry["player-info"];
@@ -417,4 +420,60 @@ export async function initialize(store, scene, remountUI) {
   });
 
   setupMonetization(hubScene, localPlayer);
+
+  // news feed and chat integration, behind a feature switch as it needs the new hubs ui
+  if (messageDispatch) {
+    // fetch news feed
+    const updateFeed = async () => {
+      const { messages, more } = await activities.feedAsChat();
+      messages.forEach(detail => {
+        messageDispatch.dispatchEvent(new CustomEvent("message", { detail }));
+      });
+      return more;
+    };
+    updateFeed();
+    // event from "load more" button at top of in chat sidebar
+    window.addEventListener("immers-load-more-history", async () => {
+      const more = await updateFeed();
+      window.dispatchEvent(new CustomEvent("immers-more-history-loaded", { detail: more }));
+    });
+
+    // stream new activity while in room
+    immerSocket.on("inbox-update", activity => {
+      activity = JSON.parse(activity);
+      if (activity.type === "Create") {
+        const detail = activities.activityAsChat(activity);
+        messageDispatch.dispatchEvent(new CustomEvent("message", { detail }));
+      }
+    });
+    // intercept outgoing messages and post to immers space feed
+    messageDispatch.addEventListener("message", ({ detail: message }) => {
+      // skip if incoming message or loaded from history
+      if (!message.sent || message.isImmersFeed) {
+        return;
+      }
+      // Send to immers id of everyone in room so all chat goes through immers and
+      // we don't have to worry about duplicate messages appearing in chat
+      const localAudience = Object.values(window.APP.hubChannel.presence.state)
+        .map(presence => presence.metas[presence.metas.length - 1]?.profile.id)
+        .filter(id => id && id !== actorObj.id);
+      // send activity
+      let task;
+      switch (message.type) {
+        case "chat":
+          task = activities.note(message.body, localAudience, true, null);
+          break;
+        case "image":
+        case "photo":
+          task = activities.image(message.body.src, localAudience, true, null);
+          break;
+        case "video":
+          task = activities.video(message.body.src, localAudience, true, null);
+          break;
+        default:
+          console.log("Chat message not shared", message);
+      }
+      task.catch(err => console.error(`Error sharing chat: ${err.message}`));
+    });
+  }
 }

--- a/src/utils/immers/activities.js
+++ b/src/utils/immers/activities.js
@@ -1,0 +1,199 @@
+export default class Activities {
+  static JSONLDMime = "application/activity+json";
+  static PublicAddress = "as:Public";
+  constructor(localImmer) {
+    this.localImmer = localImmer;
+    this.homeImmer = null;
+    this.token = null;
+    this.actor = null;
+    this.place = null;
+    this.nextInboxPage = null;
+    this.nextOutboxPage = null;
+    this.inboxStartDate = new Date();
+    this.outboxStartDate = this.inboxStartDate;
+    this.friends = [];
+  }
+
+  trustedIRI(IRI) {
+    return IRI.startsWith(this.localImmer) || IRI.startsWith(this.homeImmer);
+  }
+
+  async getObject(IRI) {
+    if (this.trustedIRI(IRI)) {
+      const headers = { Accept: Activities.JSONLDMime };
+      if (this.token) {
+        headers.Authorization = `Bearer ${this.token}`;
+      }
+      const result = await window.fetch(IRI, { headers });
+      if (!result.ok) {
+        throw new Error(`Object fetch error ${result.message}`);
+      }
+      return result.json();
+    } else {
+      throw new Error("Object fetch proxy not implemented");
+    }
+  }
+
+  async inbox() {
+    let col;
+    if (this.nextInboxPage === null) {
+      col = await this.getObject(this.actor.inbox);
+      if (!col.orderedItems && col.first) {
+        col = await this.getObject(col.first);
+      }
+    } else if (this.nextInboxPage) {
+      col = await this.getObject(this.nextInboxPage);
+    }
+    this.nextInboxPage = col?.next;
+    return col;
+  }
+
+  async outbox() {
+    let col;
+    if (this.nextOutboxPage === null) {
+      col = await this.getObject(this.actor.outbox);
+      if (!col.orderedItems && col.first) {
+        col = await this.getObject(col.first);
+      }
+    } else if (this.nextOutboxPage) {
+      col = await this.getObject(this.nextOutboxPage);
+    }
+    this.nextOutboxPage = col?.next;
+    return col;
+  }
+
+  async inboxAsChat() {
+    const inbox = await this.inbox();
+    if (!inbox?.orderedItems?.length) {
+      return [];
+    }
+    this.inboxStartDate = new Date(inbox.orderedItems[inbox.orderedItems.length - 1].published);
+    return inbox.orderedItems.map(act => this.activityAsChat(act)).filter(message => message.body);
+  }
+
+  async outboxAsChat() {
+    const outbox = await this.outbox();
+    if (!outbox?.orderedItems?.length) {
+      return [];
+    }
+    this.outboxStartDate = new Date(outbox.orderedItems[outbox.orderedItems.length - 1].published);
+    return outbox.orderedItems.map(act => this.activityAsChat(act, true)).filter(message => message.body);
+  }
+
+  async feedAsChat() {
+    const messages = (await this.inboxAsChat()).concat(await this.outboxAsChat());
+    // try to balance amount of time covered by inbox & outbox feeds
+    if (this.inboxStartDate > this.outboxStartDate) {
+      while (this.inboxStartDate > this.outboxStartDate && this.nextInboxPage) {
+        messages.push(...(await this.inboxAsChat()));
+      }
+    } else {
+      while (this.outboxStartDate > this.inboxStartDate && this.nextOutboxPage) {
+        messages.push(...(await this.outboxAsChat()));
+      }
+    }
+    return {
+      messages,
+      more: this.nextOutboxPage || this.nextInboxPage
+    };
+  }
+
+  postActivity(activity) {
+    if (!this.trustedIRI(this.actor.outbox)) {
+      throw new Error("Inavlid outbox address");
+    }
+    return window.fetch(this.actor.outbox, {
+      method: "POST",
+      headers: {
+        "Content-Type": Activities.JSONLDMime,
+        Authorization: `Bearer ${this.token}`
+      },
+      body: JSON.stringify(activity)
+    });
+  }
+
+  note(content, to, isPublic, summary) {
+    const obj = {
+      content,
+      type: "Note",
+      attributedTo: this.actor.id,
+      context: this.place,
+      to: [this.actor.followers, ...to]
+    };
+    if (summary) {
+      obj.summary = summary;
+    }
+    if (isPublic) {
+      obj.to.push(Activities.PublicAddress);
+    }
+    return this.postActivity(obj);
+  }
+
+  image(url, to, isPublic, summary) {
+    const obj = {
+      url,
+      type: "Image",
+      attributedTo: this.actor.id,
+      context: this.place,
+      to: [this.actor.followers, ...to]
+    };
+    if (summary) {
+      obj.summary = summary;
+    }
+    if (isPublic) {
+      obj.to.push(Activities.PublicAddress);
+    }
+    return this.postActivity(obj);
+  }
+
+  video(url, to, isPublic, summary) {
+    const obj = {
+      url,
+      type: "Video",
+      attributedTo: this.actor.id,
+      context: this.place,
+      to: [this.actor.followers, ...to]
+    };
+    if (summary) {
+      obj.summary = summary;
+    }
+    if (isPublic) {
+      obj.to.push(Activities.PublicAddress);
+    }
+    return this.postActivity(obj);
+  }
+
+  activityAsChat(activity, outbox = false) {
+    const message = {
+      isImmersFeed: true,
+      isFriend: this.friends.some(status => status.actor.id === activity.actor.id),
+      sent: outbox,
+      context: activity.object?.context,
+      timestamp: new Date(activity.published).getTime(),
+      name: activity.actor.name,
+      sessionId: activity.actor.id,
+      icon: activity.actor.icon,
+      immer: new URL(activity.actor.id).hostname
+    };
+    switch (activity.object?.type) {
+      case "Note":
+        message.type = "chat";
+        message.body = activity.object.content;
+        break;
+      case "Image":
+        message.type = "photo";
+        message.body = { src: activity.object.url };
+        break;
+      case "Video":
+        message.type = "video";
+        message.body = { src: activity.object.url };
+        break;
+      default:
+        if (activity.summary) {
+          message.type = "activity";
+          message.body = activity.summary;
+        }
+    }
+    return message;
+  }
+}


### PR DESCRIPTION
Requires immers server update: immers-space/immers#21

This is all the changes for chat integration  on the immers code side. It is behind a feature switch (addition of `messageDispatch` argument to initialize function) so it won't have noticeable impact when running without the react UI portion of the feature

- new Activities class to start consolidating ActivityPub API code
- Add summary text to Arrive/Leave activities to make them easier to display
- Remove obsolete Leave method (leave is posted via socket close event)
- Change icon format to be Image object for fediverse compat

Chat & history items behind feature switch (needs new UI in #26):
- fetch inbox & outbox history and send into hubs messaging system for display in chat
- intercept outgoing chat messages and convert to Immers activity delivered to room occupants and friends
- stream new inbox activities while connected and send to hubs messaging