### PR TITLE
Friend behavior

### DIFF
--- a/src/components/immers/immers-follow-button.js
+++ b/src/components/immers/immers-follow-button.js
@@ -4,21 +4,41 @@
  * @component immers-follow-button
  */
 AFRAME.registerComponent("immers-follow-button", {
+  schema: { relation: { type: "string", default: "none" } },
   init() {
     NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
       this.playerEl = networkedEl;
       this.playerEl.addEventListener("stateadded", this.onState);
-      if (this.playerEl.is("friend")) {
-        this.setFriend();
+      if (this.playerEl.is("immers-follow-friend")) {
+        this.el.setAttribute("immers-follow-button", { relation: "friend" });
       }
     });
     this.textEl = this.el.querySelector("[text]");
+    // avoid accidental double clicks
+    let lastClickTime = 0;
     this.onClick = () => {
-      this.follow(this.playerEl.components["player-info"].data.immersId);
+      const now = Date.now();
+      if (now - lastClickTime < 500) {
+        return;
+      }
+      lastClickTime = now;
+      switch (this.data.relation) {
+        case "none":
+          this.action("immers-follow", "pending");
+          break;
+        case "request":
+          this.action("immers-follow-accept", "friend");
+          break;
+        case "friend":
+          // TODO: unfriend
+          // this.action("immers-follow-reject", "none");
+          break;
+      }
     };
     this.onState = event => {
-      if (event.detail === "friend") {
-        this.setFriend();
+      const friendState = event.detail.split("immers-follow-")[1];
+      if (friendState) {
+        this.el.setAttribute("immers-follow-button", { relation: friendState });
       }
     };
   },
@@ -30,6 +50,24 @@ AFRAME.registerComponent("immers-follow-button", {
     }
   },
 
+  update() {
+    let newText;
+    switch (this.data.relation) {
+      case "request":
+        newText = "Accept friend";
+        break;
+      case "pending":
+        newText = "Reqest sent";
+        break;
+      case "friend":
+        newText = "Unfriend";
+        break;
+      default:
+        newText = "Add friend";
+    }
+    this.textEl.setAttribute("text", "value", newText);
+  },
+
   pause() {
     this.el.object3D.removeEventListener("interact", this.onClick);
     if (this.playerEl) {
@@ -37,14 +75,9 @@ AFRAME.registerComponent("immers-follow-button", {
     }
   },
 
-  follow(targetId) {
-    if (!this.playerEl.is("friend")) {
-      this.el.emit("immers-follow", targetId);
-      this.textEl.setAttribute("text", "value", "Pending");
-    }
-  },
-
-  setFriend() {
-    this.textEl.setAttribute("text", "value", "Unfollow");
+  action(eventName, newRelation) {
+    const targetId = this.playerEl.getAttribute("player-info").immersId;
+    this.el.emit(eventName, targetId);
+    this.el.setAttribute("immers-follow-button", { relation: newRelation });
   }
 });

--- a/src/components/immers/immers-follow-button.js
+++ b/src/components/immers/immers-follow-button.js
@@ -4,7 +4,7 @@
  * @component immers-follow-button
  */
 AFRAME.registerComponent("immers-follow-button", {
-  schema: { relation: { type: "string", default: "none" } },
+  schema: { relation: { type: "string", default: "none", oneOf: ["none", "request", "friend", "pending"] } },
   init() {
     NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
       this.playerEl = networkedEl;
@@ -32,8 +32,7 @@ AFRAME.registerComponent("immers-follow-button", {
           this.action("immers-follow-accept", "friend");
           break;
         case "friend":
-          // TODO: unfriend
-          // this.action("immers-follow-reject", "none");
+          this.action("immers-follow-reject", "none");
           break;
       }
     };

--- a/src/components/immers/immers-follow-button.js
+++ b/src/components/immers/immers-follow-button.js
@@ -11,6 +11,8 @@ AFRAME.registerComponent("immers-follow-button", {
       this.playerEl.addEventListener("stateadded", this.onState);
       if (this.playerEl.is("immers-follow-friend")) {
         this.el.setAttribute("immers-follow-button", { relation: "friend" });
+      } else if (this.playerEl.is("immers-follow-request")) {
+        this.el.setAttribute("immers-follow-button", { relation: "request" });
       }
     });
     this.textEl = this.el.querySelector("[text]");

--- a/src/components/player-info.js
+++ b/src/components/player-info.js
@@ -114,7 +114,7 @@ AFRAME.registerComponent("player-info", {
 
   update(oldData) {
     this.applyProperties();
-    if (this.data.immersId !== oldData.immersId) {
+    if (oldData.immersId !== undefined && this.data.immersId !== oldData.immersId) {
       this.el.emit("immers-id-changed", this.data.immersId);
       this.el.sceneEl.emit("immers-player-monetization", {
         monetized: false,

--- a/src/hub.html
+++ b/src/hub.html
@@ -160,7 +160,7 @@
                                             <a-entity text="value: +; anchor: center; align: center; color: #ccc; letterSpacing: 4; width: 2.5;" text-raycast-hack position="0 0 0.001" scale="0.85 0.85 0.85"></a-entity>
                                         </a-entity>
                                         <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" immers-follow-button position="0 0.3 .35">
-                                            <a-entity text="value:Follow; width:2.5; align:center;" text-raycast-hack position="0 0 0.001"></a-entity>
+                                            <a-entity text="value:Follow; width:1.6; align:center;" text-raycast-hack position="0 0 0.001"></a-entity>
                                         </a-entity>
                                         <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" block-button position="0 0 .35">
                                             <a-entity text="value:Hide; width:2.5; align:center;" text-raycast-hack position="0 0 0.001"></a-entity>

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -4,7 +4,7 @@ import { fetchAvatar } from "./avatar-utils";
 import { setupMonetization } from "./immers/monetization";
 import Activities from "./immers/activities";
 const localImmer = configs.IMMERS_SERVER;
-console.log("immers.space client v0.5.0");
+console.log("immers.space client v0.6.0");
 const jsonldMime = "application/activity+json";
 // avoid race between auth and initialize code
 let resolveAuth;
@@ -93,15 +93,6 @@ export function updateProfile(actorObj, update) {
     to: actorObj.followers
   };
   return postActivity(actorObj.outbox, activity);
-}
-
-export function follow(actorObj, targetId) {
-  return postActivity(actorObj.outbox, {
-    type: "Follow",
-    actor: actorObj.id,
-    object: targetId,
-    to: targetId
-  });
 }
 
 export function arrive(actorObj) {
@@ -360,6 +351,24 @@ export async function initialize(store, scene, remountUI, messageDispatch, creat
 
   // friends list
   let friendsCol;
+  const setFriendState = (immersId, el) => {
+    // friends not loaded or is myself
+    if (!friendsCol || immersId === actorObj.id) {
+      return;
+    }
+    const friendStatus = friendsCol.orderedItems.find(act => act.actor.id === immersId);
+    // inReplyTo on a follow means it is a followback, don't show accept prompt (already a friend)
+    if (friendStatus?.type === "Follow" && !friendStatus?.inReplyTo) {
+      el.removeState("immers-follow-friend");
+      el.addState("immers-follow-request");
+    } else if (friendStatus) {
+      el.removeState("immers-follow-request");
+      el.addState("immers-follow-friend");
+    } else {
+      el.removeState("immers-follow-request");
+      el.removeState("immers-follow-friend");
+    }
+  };
   const updateFriends = async () => {
     if (store.state.profile.id) {
       const profile = store.state.profile;
@@ -368,13 +377,7 @@ export async function initialize(store, scene, remountUI, messageDispatch, creat
       remountUI({ friends: friendsCol.orderedItems, handle: profile.handle });
       // update follow button for new friends
       const players = window.APP.componentRegistry["player-info"];
-      if (players) {
-        players.forEach(infoComp => {
-          if (friendsCol.orderedItems.some(act => act.actor.id === infoComp.data.immersId)) {
-            infoComp.el.addState("friend");
-          }
-        });
-      }
+      players?.forEach(infoComp => setFriendState(infoComp.data.immersId, infoComp.el));
     }
   };
   updateFriends();
@@ -403,21 +406,24 @@ export async function initialize(store, scene, remountUI, messageDispatch, creat
   });
 
   // entity interactions
-  scene.addEventListener("immers-id-changed", event => {
-    if (!friendsCol) {
-      return;
-    }
-    if (friendsCol.orderedItems.some(act => act.actor.id === event.detail)) {
-      event.target.addState("friend");
-    }
-  });
+  scene.addEventListener("immers-id-changed", event => setFriendState(event.detail, event.target));
 
   scene.addEventListener("immers-follow", event => {
     if (!event.detail) {
       return;
     }
-    follow(store.state.profile, event.detail).catch(err => console.err("Error sending follow request:", err.message));
+    activities.follow(event.detail).catch(err => console.err("Error sending follow request:", err.message));
   });
+  scene.addEventListener("immers-follow-accept", event => {
+    const follow = friendsCol.orderedItems.find(act => act.actor.id === event.detail && act.type === "Follow");
+    if (!follow) {
+      return;
+    }
+    activities.accept(follow).catch(err => console.err("Error sending follow accept:", err.message));
+  });
+  // TODO: unfriend
+  // scene.addEventListener("immers-follow-reject", event => {
+  // });
 
   setupMonetization(hubScene, localPlayer);
 

--- a/src/utils/immers/activities.js
+++ b/src/utils/immers/activities.js
@@ -121,6 +121,15 @@ export default class Activities {
     });
   }
 
+  reject(objectId, recipientId) {
+    return this.postActivity({
+      type: "Reject",
+      actor: this.actor.id,
+      object: objectId,
+      to: recipientId
+    });
+  }
+
   follow(targetId) {
     return this.postActivity({
       type: "Follow",

--- a/src/utils/immers/activities.js
+++ b/src/utils/immers/activities.js
@@ -112,6 +112,24 @@ export default class Activities {
     });
   }
 
+  accept(follow) {
+    return this.postActivity({
+      type: "Accept",
+      actor: this.actor.id,
+      object: follow.id,
+      to: follow.actor
+    });
+  }
+
+  follow(targetId) {
+    return this.postActivity({
+      type: "Follow",
+      actor: this.actor.id,
+      object: targetId,
+      to: targetId
+    });
+  }
+
   note(content, to, isPublic, summary) {
     const obj = {
       content,


### PR DESCRIPTION
The goal is to create a friending flow that works like this:
1. Send a friend request
2. Other user must manually approve request
3. Then you become reciprocal friends (i.e. you both follow each other)

Requires immers-space/immers#22

Changes on the client side:

1. Upgrade `immers-follow-button` to show pending request state and allow user to accept
2. Ability to generate Accept activity
3. Differentiate current friends v. pending requests v. strangers from friends status updates

This could be even better with some notification of request and controls in the react ui to send & accept requests, but I think we've got a MVP here