### PR TITLE
Chess board position syncrhonicity

### DIFF
--- a/src/chess/chess-arbiter.js
+++ b/src/chess/chess-arbiter.js
@@ -105,9 +105,9 @@ AFRAME.registerSystem("chess-arbiter", {
     }
   },
 
-  playAs(color, id, profile) {
+  async playAs(color, id, profile) {
     if (!this.chessGame) {
-      this.chessGame = this.sceneEl.querySelector("a-entity[chess-game]");
+      this.chessGame = await this.boardPosition.addChessGame();
     }
     const colorAvailable = !this.state.players[color].id;
     if (colorAvailable) {
@@ -360,5 +360,13 @@ AFRAME.registerSystem("chess-arbiter", {
       window.NAF.utils.takeOwnership(set);
       set.parentNode.removeChild(set);
     }
+  },
+
+  registerBoardPosition(component) {
+    this.boardPosition = component;
+  },
+
+  registerGame(entity) {
+    this.chessGame = entity;
   }
 });

--- a/src/chess/chess-board-position.js
+++ b/src/chess/chess-board-position.js
@@ -2,23 +2,7 @@ AFRAME.registerComponent("chess-board-position", {
   schema: {},
   init() {
     this.addChessGame = this.addChessGame.bind(this);
-    this.networkCheck = this.networkCheck.bind(this);
-    this.networkCheck();
-  },
-  networkCheck() {
-    const entitiesObj = NAF.connection.entities.entities;
-    const entitiesArray = Object.keys(entitiesObj).map(key => entitiesObj[key]);
-    const sanityCheck = entitiesArray.filter(el => el.id === "avatar-rig").length === 1;
-    if (window.NAF.connection.isConnected() && sanityCheck) {
-      const gameRequired = entitiesArray.filter(el => el.hasAttribute("chess-game")).length === 0;
-      if (gameRequired) {
-        this.addChessGame();
-      }
-    } else {
-      setTimeout(() => {
-        this.networkCheck();
-      }, 1000);
-    }
+    this.el.sceneEl.systems["chess-arbiter"].registerBoardPosition(this);
   },
   addChessGame() {
     const bbox = new THREE.Box3();
@@ -34,11 +18,16 @@ AFRAME.registerComponent("chess-board-position", {
       `squareSize: ${squareSize}; hideBoard: true; wireframeBoard:true; teleportPlayers: true;`
     );
     game.setAttribute("networked", "template: #template-waypoint-avatar;");
-    let newPos = bbox.min;
+    const newPos = bbox.min;
     newPos.y = newPos.y - squareSize - squareSize / 4;
     newPos.x = newPos.x + squareSize / 2;
     newPos.z = newPos.z + squareSize / 2;
-    game.setAttribute("position", newPos);
+    // ensure world matrix immediately available for player teleport
+    game.object3D.position.copy(newPos);
+    game.object3D.updateMatrixWorld(true);
     this.el.sceneEl.appendChild(game);
+    return new Promise(resolve => {
+      game.addEventListener("board-loaded", () => resolve(game), { once: true });
+    });
   }
 });

--- a/src/chess/chess-board-position.js
+++ b/src/chess/chess-board-position.js
@@ -13,10 +13,7 @@ AFRAME.registerComponent("chess-board-position", {
     bbox.size(size);
     const squareSize = size.x / 8;
     const game = document.createElement("a-entity");
-    game.setAttribute(
-      "chess-game",
-      `squareSize: ${squareSize}; hideBoard: true; wireframeBoard:true; teleportPlayers: true;`
-    );
+    game.setAttribute("chess-game", `squareSize: ${squareSize}; hideBoard: true;`);
     game.setAttribute("networked", "template: #template-waypoint-avatar;");
     const newPos = bbox.min;
     newPos.y = newPos.y - squareSize - squareSize / 4;

--- a/src/chess/chess-game.js
+++ b/src/chess/chess-game.js
@@ -9,6 +9,10 @@ AFRAME.registerComponent("chess-game", {
     snapToSquare: { default: true }
   },
 
+  init() {
+    this.el.sceneEl.systems["chess-arbiter"].registerGame(this.el);
+  },
+
   update() {
     while (this.el.firstChild) {
       this.el.removeChild(this.el.firstChild);
@@ -25,6 +29,7 @@ AFRAME.registerComponent("chess-game", {
         this.data.wireframeBoard
       }; `
     );
+    board.addEventListener("loaded", () => this.el.emit("board-loaded"), { once: true });
     this.el.appendChild(board);
   }
 });

--- a/src/chess/chess-piece.js
+++ b/src/chess/chess-piece.js
@@ -97,19 +97,15 @@ AFRAME.registerComponent("chess-piece", {
 
   autoSetY(entity) {
     const bbox = new THREE.Box3();
-    bbox.setFromObject(entity.object3D);
-    if (isFinite(bbox.min.y)) {
-      const height = bbox.max.y/2 - bbox.min.y/2;
-      const autoY = height + this.squareSize * 1.5;
-      this.data.pieceY = autoY;
-      const pos = entity.getAttribute("position");
-      pos.y = autoY;
-      entity.setAttribute("position", pos);
-    } else {
-      setTimeout(() => {
-        this.autoSetY(entity);
-      }, 1000);
-    }
+    entity.addEventListener("object3dset", () => {
+      bbox.setFromObject(entity.object3D);
+      if (isFinite(bbox.min.y)) {
+        const height = bbox.max.y/2 - bbox.min.y/2;
+        const autoY = height + this.squareSize * 1.5;
+        this.data.pieceY = autoY;
+        entity.object3D.position.y = autoY;
+      }
+    });
   },
 
   announcePiece(piece) {


### PR DESCRIPTION
Create the chess-game on demand in response to user input so we don't have to worry about NAF initial sync timing

Use object3dset event for timing of piece y correction

Use [object3D.position directly](https://aframe.io/docs/1.2.0/components/position.html#updating-position) to avoid some synchronicity issues with getAttribute on newly created entities

Remove wireframe debug setting and a teleport setting that wasn't related to chess-game