### PR TITLE
Chat MVP - UI side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27792,6 +27792,11 @@
       "dev": true,
       "optional": true
     },
+    "nanoid": {
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
+      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -29180,6 +29185,11 @@
       "resolved": "https://registry.npmjs.org/parse-repo/-/parse-repo-1.0.4.tgz",
       "integrity": "sha1-dLkdLLhnXRG5mXagBl9s4X+hvMg=",
       "dev": true
+    },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
     },
     "parse-url": {
       "version": "5.0.2",
@@ -32282,9 +32292,9 @@
       }
     },
     "react-popper-2": {
-      "version": "npm:react-popper@2.2.4",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.4.tgz",
-      "integrity": "sha512-NacOu4zWupdQjVXq02XpTD3yFPSfg5a7fex0wa3uGKVkFK7UN6LvVxgcb+xYr56UCuWiNPMH20tntdVdJRwYew==",
+      "version": "npm:react-popper@2.2.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
       "requires": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
@@ -33791,6 +33801,111 @@
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
           }
+        }
+      }
+    },
+    "sanitize-html": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.3.3.tgz",
+      "integrity": "sha512-DCFXPt7Di0c6JUnlT90eIgrjs6TsJl/8HYU3KLdmrVclFN4O0heTcVbJiMa23OKVr6aR051XYtsgd8EWwEBwUA==",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "klona": "^2.0.3",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.0.2"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+          "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+        },
+        "deepmerge": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+          "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+        },
+        "dom-serializer": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
+          "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+        },
+        "domhandler": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
+          "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        },
+        "domutils": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.2.tgz",
+          "integrity": "sha512-MHTthCb1zj8f1GVfRpeZUbohQf/HdBos0oX5gZcQFepOZPLLRyj6Wn7XS7EMnY7CVpwv8863u2vyE83Hfu28HQ==",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.1.0"
+          }
+        },
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "htmlparser2": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+          "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "domutils": "^2.5.2",
+            "entities": "^2.0.0"
+          }
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        },
+        "klona": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
+          "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
+        },
+        "postcss": {
+          "version": "8.2.9",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
+          "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
+          "requires": {
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.22",
+            "source-map": "^0.6.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22059,7 +22059,7 @@
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
@@ -24609,7 +24609,7 @@
     },
     "http-deceiver": {
       "version": "1.2.7",
-      "resolved": "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
       "dev": true
     },
@@ -25530,7 +25530,7 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "react-textarea-autosize": "^8.2.0",
     "react-use-css-breakpoints": "^1.0.3",
     "resize-observer-polyfill": "^1.5.1",
+    "sanitize-html": "^2.3.2",
     "screenfull": "^4.0.1",
     "semver": "^7.3.2",
     "socket.io-client": "^2.3.0",

--- a/src/hub.js
+++ b/src/hub.js
@@ -1478,10 +1478,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       sent: session_id === socket.params().session_id
     };
 
-    // replaced by immers feed
-    // if (scene.is("vr-mode")) {
-    //   createInWorldLogMessage(incomingMessage);
-    // }
+    if (scene.is("vr-mode")) {
+      createInWorldLogMessage(incomingMessage);
+    }
 
     messageDispatch.receive(incomingMessage);
   });

--- a/src/react-components/input/ToolbarButton.js
+++ b/src/react-components/input/ToolbarButton.js
@@ -9,7 +9,7 @@ export const statusColors = ["red", "orange", "green"];
 
 export const ToolbarButton = forwardRef(
   (
-    { preset, className, iconContainerClassName, children, icon, label, selected, large, statusColor, ...rest },
+    { preset, className, iconContainerClassName, children, icon, label, selected, large, small, statusColor, ...rest },
     ref
   ) => {
     return (
@@ -18,7 +18,7 @@ export const ToolbarButton = forwardRef(
         className={classNames(
           styles.toolbarButton,
           styles[preset],
-          { [styles.selected]: selected, [styles.large]: large },
+          { [styles.selected]: selected, [styles.large]: large, [styles.small]: small },
           className
         )}
         {...rest}

--- a/src/react-components/input/ToolbarButton.scss
+++ b/src/react-components/input/ToolbarButton.scss
@@ -42,6 +42,14 @@
   }
 }
 
+:local(.small) {
+  width: 48px;
+}
+
+:local(.small) :local(.icon-container) {
+  flex-shrink: 0;
+}
+
 :local(.large) :local(.icon-container) {
   width: 96px;
   height: 96px;

--- a/src/react-components/room/ChatSidebar.js
+++ b/src/react-components/room/ChatSidebar.js
@@ -302,10 +302,10 @@ ChatMessageList.propTypes = {
   children: PropTypes.node
 };
 
-export function ChatSidebar({ onClose, children, ...rest }) {
+export function ChatSidebar({ onClose, title, children, ...rest }) {
   return (
     <Sidebar
-      title={<FormattedMessage id="chat-sidebar.title" defaultMessage="Chat" />}
+      title={title || <FormattedMessage id="chat-sidebar.title" defaultMessage="Chat" />}
       beforeTitle={<CloseButton onClick={onClose} />}
       contentClassName={styles.content}
       {...rest}
@@ -317,6 +317,7 @@ export function ChatSidebar({ onClose, children, ...rest }) {
 
 ChatSidebar.propTypes = {
   onClose: PropTypes.func,
+  title: PropTypes.any,
   onScrollList: PropTypes.func,
   children: PropTypes.node,
   listRef: PropTypes.func
@@ -328,7 +329,9 @@ export function ChatToolbarButton(props) {
       {...props}
       icon={<ChatIcon />}
       preset="blue"
-      label={<FormattedMessage id="chat-toolbar-button" defaultMessage="Chat" />}
+      small
+      title="Chat with room occupants that is not saved"
+      label={<FormattedMessage id="chat-toolbar-button" defaultMessage="Local Chat" />}
     />
   );
 }

--- a/src/react-components/room/ChatSidebarContainer.js
+++ b/src/react-components/room/ChatSidebarContainer.js
@@ -15,7 +15,6 @@ import { useMaintainScrollPosition } from "../misc/useMaintainScrollPosition";
 import { spawnChatMessage } from "../chat-message";
 import { discordBridgesForPresences } from "../../utils/phoenix-utils";
 import { useIntl } from "react-intl";
-import { ImmersChatMessage, ImmersMoreHistoryButton } from "./ImmersReact";
 
 const ChatContext = createContext({ messageGroups: [], sendMessage: () => {} });
 
@@ -43,29 +42,6 @@ function processChatMessage(messageGroups, newMessage) {
   const now = Date.now();
   const { name, sent, sessionId, ...messageProps } = newMessage;
 
-  if (messageProps.isImmersFeed) {
-    // insert according to timestamp
-    const newMessageGroups = messageGroups.slice();
-    const i = newMessageGroups.findIndex(group => messageProps.timestamp < group.timestamp);
-    newMessageGroups.splice(i === -1 ? newMessageGroups.length : i, 0, {
-      id: uniqueMessageId++,
-      isImmersFeed: messageProps.isImmersFeed,
-      isFriend: messageProps.isFriend,
-      timestamp: messageProps.timestamp,
-      sent: sent,
-      sender: name,
-      icon: messageProps.icon,
-      senderSessionId: sessionId,
-      context: messageProps.context,
-      immer: messageProps.immer,
-      messages: [{ id: uniqueMessageId++, ...messageProps }]
-    });
-    return newMessageGroups;
-  }
-  // local chat is ignored in favor of immers feed which includes it
-  if (!sent) {
-    return messageGroups;
-  }
   if (shouldCreateNewMessageGroup(messageGroups, newMessage, now)) {
     return [
       ...messageGroups,
@@ -276,12 +252,9 @@ export function ChatSidebarContainer({ scene, canSpawnMessages, presences, occup
   return (
     <ChatSidebar onClose={onClose}>
       <ChatMessageList ref={listRef} onScroll={onScrollList}>
-        <ImmersMoreHistoryButton />
-        {messageGroups.map(({ id, systemMessage, isImmersFeed, ...rest }) => {
+        {messageGroups.map(({ id, systemMessage, ...rest }) => {
           if (systemMessage) {
             return <SystemMessage key={id} {...rest} />;
-          } else if (isImmersFeed) {
-            return <ImmersChatMessage key={id} {...rest} />;
           } else {
             return <ChatMessageGroup key={id} {...rest} />;
           }

--- a/src/react-components/room/ImmersFeedSidebarContainer.js
+++ b/src/react-components/room/ImmersFeedSidebarContainer.js
@@ -1,0 +1,236 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import { ChatSidebar, ChatMessageList, ChatInput, SendMessageButton } from "./ChatSidebar";
+import { useMaintainScrollPosition } from "../misc/useMaintainScrollPosition";
+import { FormattedMessage, useIntl } from "react-intl";
+import { ImmersChatMessage, ImmersIcon, ImmersMoreHistoryButton } from "./ImmersReact";
+import { ToolbarButton } from "../input/ToolbarButton";
+import { ReactComponent as PublicIcon } from "../icons/Scene.svg";
+import { ReactComponent as FriendsIcon } from "../icons/People.svg";
+import { ReactComponent as LocalIcon } from "../icons/Home.svg";
+import { IconButton } from "../input/IconButton";
+import styles from "./ChatSidebar.scss";
+
+const ImmersFeedContext = createContext({ messageGroups: [], sendMessage: () => {} });
+
+let uniqueMessageId = 0;
+
+function processChatMessage(messageGroups, newMessage) {
+  const { name, sent, sessionId, ...messageProps } = newMessage;
+
+  if (messageProps.isImmersFeed) {
+    // insert according to timestamp
+    const newMessageGroups = messageGroups.slice();
+    const i = newMessageGroups.findIndex(group => messageProps.timestamp < group.timestamp);
+    newMessageGroups.splice(i === -1 ? newMessageGroups.length : i, 0, {
+      id: uniqueMessageId++,
+      isImmersFeed: messageProps.isImmersFeed,
+      isFriend: messageProps.isFriend,
+      timestamp: messageProps.timestamp,
+      sent: sent,
+      sender: name,
+      icon: messageProps.icon,
+      senderSessionId: sessionId,
+      context: messageProps.context,
+      immer: messageProps.immer,
+      messages: [{ id: uniqueMessageId++, ...messageProps }]
+    });
+    return newMessageGroups;
+  }
+}
+
+// Returns the new message groups array when we receive a message.
+// If the message is ignored, we return the original message group array.
+function updateMessageGroups(messageGroups, newMessage) {
+  switch (newMessage.type) {
+    case "chat":
+    case "image":
+    case "photo":
+    case "video":
+    case "activity":
+      return processChatMessage(messageGroups, newMessage);
+    default:
+      return messageGroups;
+  }
+}
+
+export function ImmersFeedContextProvider({ messageDispatch, children }) {
+  const [messageGroups, setMessageGroups] = useState([]);
+  const [unreadMessages, setUnreadMessages] = useState(false);
+  const [audience, setAudience] = useState("public");
+
+  useEffect(
+    () => {
+      function onReceiveMessage(event) {
+        const newMessage = event.detail;
+        if (!newMessage.isImmersFeed) {
+          return;
+        }
+        setMessageGroups(messages => updateMessageGroups(messages, newMessage));
+        if (
+          newMessage.type === "chat" ||
+          newMessage.type === "image" ||
+          newMessage.type === "photo" ||
+          newMessage.type === "video"
+        ) {
+          setUnreadMessages(true);
+        }
+      }
+
+      if (messageDispatch) {
+        messageDispatch.addEventListener("message", onReceiveMessage);
+      }
+
+      return () => {
+        if (messageDispatch) {
+          messageDispatch.removeEventListener("message", onReceiveMessage);
+        }
+      };
+    },
+    [messageDispatch, setMessageGroups, setUnreadMessages]
+  );
+
+  const sendMessage = useCallback(
+    body => {
+      if (messageDispatch) {
+        messageDispatch.dispatch({ type: "chat", body, audience });
+      }
+    },
+    [messageDispatch, audience]
+  );
+
+  const setMessagesRead = useCallback(
+    () => {
+      setUnreadMessages(false);
+    },
+    [setUnreadMessages]
+  );
+
+  return (
+    <ImmersFeedContext.Provider
+      value={{ messageGroups, unreadMessages, audience, sendMessage, setMessagesRead, setAudience }}
+    >
+      {children}
+    </ImmersFeedContext.Provider>
+  );
+}
+
+ImmersFeedContextProvider.propTypes = {
+  children: PropTypes.node,
+  messageDispatch: PropTypes.object
+};
+
+export function ImmersFeedSidebarContainer({ onClose }) {
+  const { messageGroups, sendMessage, setMessagesRead, audience, setAudience } = useContext(ImmersFeedContext);
+  const [onScrollList, listRef, scrolledToBottom] = useMaintainScrollPosition(messageGroups);
+  const [message, setMessage] = useState("");
+  const intl = useIntl();
+
+  const onKeyDown = useCallback(
+    e => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        sendMessage(e.target.value);
+        setMessage("");
+      }
+    },
+    [sendMessage, setMessage]
+  );
+
+  const onSendMessage = useCallback(
+    () => {
+      sendMessage(message);
+      setMessage("");
+    },
+    [message, sendMessage, setMessage]
+  );
+
+  useEffect(
+    () => {
+      if (scrolledToBottom) {
+        setMessagesRead();
+      }
+    },
+    [messageGroups, scrolledToBottom, setMessagesRead]
+  );
+
+  let placeholder;
+  switch (audience) {
+    case "local":
+      placeholder = intl.formatMessage({
+        id: "immersfeed-sidebar-container.input-placeholder.local",
+        defaultMessage: "Post to room"
+      });
+      break;
+    case "friends":
+      placeholder = intl.formatMessage({
+        id: "immersfeed-sidebar-container.input-placeholder.friends",
+        defaultMessage: "Post to room and friends"
+      });
+      break;
+    case "public":
+      placeholder = intl.formatMessage({
+        id: "immersfeed-sidebar-container.input-placeholder.public",
+        defaultMessage: "Post publicly"
+      });
+      break;
+  }
+  const audiences = ["local", "friends", "public"];
+  const audienceButton = (
+    <IconButton
+      className={styles.chatInputIcon}
+      onClick={() => setAudience(audiences[(audiences.indexOf(audience) + 1) % 3])}
+      title="Change audience"
+    >
+      {audience === "public" && <PublicIcon />}
+      {audience === "friends" && <FriendsIcon />}
+      {audience === "local" && <LocalIcon />}
+    </IconButton>
+  );
+  return (
+    <ChatSidebar onClose={onClose} title="Immers Space metaverse chat">
+      <ChatMessageList ref={listRef} onScroll={onScrollList}>
+        <ImmersMoreHistoryButton />
+        {messageGroups.map(({ id, ...rest }) => {
+          return <ImmersChatMessage key={id} {...rest} />;
+        })}
+      </ChatMessageList>
+      <ChatInput
+        id="chat-input"
+        onKeyDown={onKeyDown}
+        onChange={e => setMessage(e.target.value)}
+        placeholder={placeholder}
+        value={message}
+        afterInput={
+          <>
+            <SendMessageButton onClick={onSendMessage} disabled={message.length === 0} />
+            {audienceButton}
+          </>
+        }
+      />
+    </ChatSidebar>
+  );
+}
+
+ImmersFeedSidebarContainer.propTypes = {
+  canSpawnMessages: PropTypes.bool,
+  presences: PropTypes.object.isRequired,
+  occupantCount: PropTypes.number.isRequired,
+  scene: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired
+};
+
+export function ImmersFeedToolbarButtonContainer(props) {
+  const { unreadMessages } = useContext(ImmersFeedContext);
+  return (
+    <ToolbarButton
+      {...props}
+      icon={<ImmersIcon />}
+      statusColor={unreadMessages ? "orange" : undefined}
+      preset="basic"
+      small
+      title="Chat across the metaverse that is saved in your profile"
+      label={<FormattedMessage id="immers-feed-toolbar-button" defaultMessage="Immers Chat" />}
+    />
+  );
+}

--- a/src/react-components/room/ImmersReact.js
+++ b/src/react-components/room/ImmersReact.js
@@ -9,6 +9,15 @@ import { proxiedUrlFor } from "../../utils/media-url-utils";
 import immersLogo from "../../assets/images/immers_logo.png";
 import merge from "deepmerge";
 
+function proxyAndGetMessageComponent(message) {
+  // media urls need proxy to pass CSP & CORS
+  if (message.body?.src) {
+    message = merge({}, message);
+    message.body.src = proxiedUrlFor(message.body.src);
+  }
+  return getMessageComponent(message);
+}
+
 export function ImmerLink({ place }) {
   if (!place) {
     return null;
@@ -58,7 +67,9 @@ export function ImmersChatMessage({ sent, sender, timestamp, isFriend, icon, imm
         <span className={styles.immerName}>[{immer}]</span>&nbsp;|&nbsp;<ImmerLink place={context} />&nbsp;|{" "}
         <FormattedRelativeTime updateIntervalInSeconds={10} value={(timestamp - Date.now()) / 1000} />
       </p>
-      <ul className={chatStyles.messageGroupMessages}>{messages.map(message => proxyAndGetMessageComponent(message))}</ul>
+      <ul className={chatStyles.messageGroupMessages}>
+        {messages.map(message => proxyAndGetMessageComponent(message))}
+      </ul>
     </li>
   );
 }
@@ -69,10 +80,7 @@ ImmersChatMessage.propTypes = {
   timestamp: PropTypes.any,
   messages: PropTypes.array,
   immer: PropTypes.string,
-  icon: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object
-  ]),
+  icon: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   isFriend: PropTypes.bool,
   context: PropTypes.object
 };
@@ -91,6 +99,10 @@ ImmersImageIcon.propTypes = {
 
 export function ImmersFriendIcon() {
   return <ImmersImageIcon src={immersLogo} title={"Immers Space Friend"} />;
+}
+
+export function ImmersIcon() {
+  return <ImmersImageIcon src={immersLogo} />;
 }
 
 export function ImmersAvatarIcon({ avi }) {
@@ -134,13 +146,4 @@ export function ImmersMoreHistoryButton() {
       </div>
     )
   );
-}
-
-function proxyAndGetMessageComponent(message) {
-  // media urls need proxy to pass CSP & CORS
-  if (message.body?.src) {
-    message = merge({}, message);
-    message.body.src = proxiedUrlFor(message.body.src);
-  }
-  return getMessageComponent(message);
 }

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -94,6 +94,11 @@ import { TweetModalContainer } from "./room/TweetModalContainer";
 import { TipContainer, FullscreenTip } from "./room/TipContainer";
 import { SpectatingLabel } from "./room/SpectatingLabel";
 import { SignInMessages } from "./auth/SignInModal";
+import {
+  ImmersFeedContextProvider,
+  ImmersFeedSidebarContainer,
+  ImmersFeedToolbarButtonContainer
+} from "./room/ImmersFeedSidebarContainer";
 
 const avatarEditorDebug = qsTruthy("avatarEditorDebug");
 
@@ -1427,6 +1432,15 @@ class UIRoot extends Component {
                           onClose={() => this.setSidebar(null)}
                         />
                       )}
+                      {this.state.sidebarId === "feed" && (
+                        <ImmersFeedSidebarContainer
+                          presences={this.props.presences}
+                          occupantCount={this.occupantCount()}
+                          canSpawnMessages={entered && this.props.hubChannel.can("spawn_and_move_media")}
+                          scene={this.props.scene}
+                          onClose={() => this.setSidebar(null)}
+                        />
+                      )}
                       {this.state.sidebarId === "objects" && (
                         <ObjectsSidebarContainer
                           hubChannel={this.props.hubChannel}
@@ -1556,6 +1570,7 @@ class UIRoot extends Component {
                       </>
                     )}
                     <ChatToolbarButtonContainer onClick={() => this.toggleSidebar("chat")} />
+                    <ImmersFeedToolbarButtonContainer onClick={() => this.toggleSidebar("feed")} />
                     {entered &&
                       isMobileVR && (
                         <ToolbarButton
@@ -1632,16 +1647,19 @@ function UIRootHooksWrapper(props) {
 
   return (
     <ChatContextProvider messageDispatch={props.messageDispatch}>
-      <ObjectListProvider scene={props.scene}>
-        <UIRoot breakpoint={breakpoint} {...props} />
-      </ObjectListProvider>
+      <ImmersFeedContextProvider messageDispatch={props.immersMessageDispatch}>
+        <ObjectListProvider scene={props.scene}>
+          <UIRoot breakpoint={breakpoint} {...props} />
+        </ObjectListProvider>
+      </ImmersFeedContextProvider>
     </ChatContextProvider>
   );
 }
 
 UIRootHooksWrapper.propTypes = {
   scene: PropTypes.object.isRequired,
-  messageDispatch: PropTypes.object
+  messageDispatch: PropTypes.object,
+  immersMessageDispatch: PropTypes.object
 };
 
 export default UIRootHooksWrapper;

--- a/src/utils/chat-message.js
+++ b/src/utils/chat-message.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Linkify from "react-linkify";
 import { toArray as toEmojis } from "react-emoji-render";
+import sanitize from "sanitize-html";
 
 const emojiRegex = /(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|[\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|[\ud83c[\ude32-\ude3a]|[\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])/;
 
@@ -12,7 +13,10 @@ export function formatMessageBody(body, { emojiClassName } = {}) {
   const messages = cleanedBody.split("\n").map((message, i) => (
     <p key={i}>
       <Linkify properties={{ target: "_blank", rel: "noopener referrer" }}>
-        {toEmojis(message, { className: emojiClassName })}
+        {toEmojis(message, { className: emojiClassName }).map(
+          (node, i) =>
+            typeof node === "string" ? <span key={i} dangerouslySetInnerHTML={{ __html: sanitize(node) }} /> : node
+        )}
       </Linkify>
     </p>
   ));


### PR DESCRIPTION
Requires #35 

* Restore Hubs' original local & impermanent chat
* Immers feed is split into a new sidebar with a new toolbar icon added
* Enable safe display of HTML content from immers feed (mainly chats coming from other fedi apps like Mastodon)
* Add privacy level toggle in immers feed chat input box
  * public - sent to local room occupants, friends list, and added to public profile
  * friends - sent to local room occupants and friends (not listed on public profile)
  * local - sent to local room occupants only (not listed on public profile)
 