### PR TITLE
Hide/Block integration

### DIFF
--- a/src/components/block-button.js
+++ b/src/components/block-button.js
@@ -7,6 +7,7 @@ AFRAME.registerComponent("block-button", {
   init() {
     this.onClick = () => {
       this.block(this.owner);
+      this.el.emit("immers-block", { clientId: this.owner });
     };
     NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
       this.owner = networkedEl.components.networked.data.owner;

--- a/src/hub.html
+++ b/src/hub.html
@@ -163,7 +163,7 @@
                                             <a-entity text="value:Follow; width:1.6; align:center;" text-raycast-hack position="0 0 0.001"></a-entity>
                                         </a-entity>
                                         <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" block-button position="0 0 .35">
-                                            <a-entity text="value:Hide; width:2.5; align:center;" text-raycast-hack position="0 0 0.001"></a-entity>
+                                            <a-entity text="value:Block; width:2.5; align:center;" text-raycast-hack position="0 0 0.001"></a-entity>
                                         </a-entity>
                                         <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" visible-if-permitted="mute_users" mute-button position="0 -0.3 .35" scale="0.8 0.8 0.8">
                                             <a-entity text="value:Mute; width:2.5; align:center;" text-raycast-hack visible-if-permitted="mute_users" position="0 0 0.001"></a-entity>

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -21,6 +21,7 @@ let hubScene;
 let localPlayer;
 let actorObj;
 let avatarsCollection;
+let blockList;
 // map of avatar urls to model objects to avoid recreating their AP representation
 // when donned from personal avatars collection
 const myAvatars = {};
@@ -382,6 +383,21 @@ export async function initialize(store, scene, remountUI, messageDispatch, creat
   updateFriends();
   immerSocket.on("friends-update", updateFriends);
 
+  blockList = await activities.blockList();
+  // hide any blocked users currently in the room
+  Object.entries(window.APP.hubChannel.presence.state).forEach(([clientId, presence]) => {
+    const immersId = presence.metas[presence.metas.length - 1]?.profile.id;
+    if (blockList.includes(immersId)) {
+      window.APP.hubChannel.hide(clientId);
+    }
+  });
+  // hide blocked users as soon as they connect
+  scene.addEventListener("presence_updated", ({ detail: { sessionId, profile } }) => {
+    if (blockList.includes(profile.id)) {
+      window.APP.hubChannel.hide(sessionId);
+    }
+  });
+
   scene.addEventListener("avatar_updated", async () => {
     const profile = store.state.profile;
     const update = {};
@@ -424,6 +440,16 @@ export async function initialize(store, scene, remountUI, messageDispatch, creat
   scene.addEventListener("immers-follow-reject", event => {
     // server converts actorId to followId for reject object
     activities.reject(event.detail, event.detail).catch(err => console.error("Error sending unfollow:", err.message));
+  });
+  // blocked
+  scene.addEventListener("immers-block", ({ detail: { clientId } }) => {
+    const presence = window.APP.hubChannel.presence.state[clientId];
+    const immersId = presence?.metas[presence.metas.length - 1]?.profile.id;
+    if (immersId) {
+      activities.block(immersId);
+      // update local copy in case blocked user reconnects
+      blockList.push(immersId);
+    }
   });
 
   setupMonetization(hubScene, localPlayer);

--- a/src/utils/immers/activities.js
+++ b/src/utils/immers/activities.js
@@ -62,6 +62,34 @@ export default class Activities {
     return col;
   }
 
+  async blockList() {
+    const blocked = [];
+    // use blocklist IRI if specified, fallback to immers default
+    const blockedIRI = this.actor.streams?.blocked || `${this.homeImmer}/blocked/${this.actor.preferredUsername}`;
+    let col;
+    try {
+      col = await this.getObject(blockedIRI);
+    } catch (err) {
+      console.warn("Unable to fetch blocklist: ", err.message);
+      return blocked;
+    }
+    if (col.orderedItems?.length) {
+      blocked.push(...col.orderedItems);
+    } else {
+      col = await this.getObject(col.first);
+      blocked.push(...col.orderedItems);
+    }
+    // fetch entire collection
+    while (col.next) {
+      col = await this.getObject(col.next);
+      if (!col.orderedItems?.length) {
+        break;
+      }
+      blocked.push(...col.orderedItems);
+    }
+    return blocked.map(b => (typeof b === "object" ? b.id : b));
+  }
+
   async inboxAsChat() {
     const inbox = await this.inbox();
     if (!inbox?.orderedItems?.length) {
@@ -188,6 +216,14 @@ export default class Activities {
       obj.to.push(Activities.PublicAddress);
     }
     return this.postActivity(obj);
+  }
+
+  block(blockeeId) {
+    return this.postActivity({
+      type: "Block",
+      actor: this.actor.id,
+      object: blockeeId
+    });
   }
 
   activityAsChat(activity, outbox = false) {


### PR DESCRIPTION
Convert the Hubs Hide button into a metaverse-wide block feature. Block someone one-time, and they are automatically hidden any time you encounter them in any immer in the future. The hubs hide is two-way, so they won't be able to see you either. They do still appear in the room presence list so you know they are there (in the future, should also do a UI-side PR to add a blocked icon to their name)

* Change Hubs avatar pause menu "Hide" button to "Block"
* When hiding in Hubs, also publish a Block activity to adds user your blocklist
* When joining a room, check if any users present are in your blocklist and automatically hide them
* When someone joins the room after you, check if they are in your blocklist and automaticall hide them