### PR TITLE
Authorization scopes & popup authorization dialog

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -34,9 +34,6 @@
     "transform-react-jsx-img-import",
     ["@babel/proposal-class-properties", { "loose": true }],
     "@babel/proposal-object-rest-spread",
-    // Samsung Internet on the Oculus Go version is stuck at version 5.2, which is a 
-    // Chromium 51, as of this writing. It needs babel to transpile async/await.
-    "@babel/plugin-transform-async-to-generator",
     "@babel/plugin-proposal-optional-chaining"
   ]
 }

--- a/.defaults.env
+++ b/.defaults.env
@@ -31,3 +31,4 @@ DEFAULT_SCENE_SID="JGLt8DP"
 # LOAD_APP_CONFIG=true
 
 IMMERS_SERVER="https://localhost:8081"
+IMMERS_SCOPE="modAdditive"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubs",
-  "version": "0.0.1",
+  "version": "1.1.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubs",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Duck-themed multi-user virtual spaces in WebVR.",
   "main": "src/index.js",
   "license": "MPL-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubs",
-  "version": "1.0.0",
+  "version": "1.1.0-alpha.0",
   "description": "Duck-themed multi-user virtual spaces in WebVR.",
   "main": "src/index.js",
   "license": "MPL-2.0",

--- a/src/components/block-button.js
+++ b/src/components/block-button.js
@@ -5,21 +5,33 @@
  */
 AFRAME.registerComponent("block-button", {
   init() {
+    this.textEl = this.el.querySelector("[text]");
     this.onClick = () => {
       this.block(this.owner);
       this.el.emit("immers-block", { clientId: this.owner });
     };
+    this.onScopeChange = () => {
+      if (this.el.sceneEl.states.includes("immers-scope-addBlocks")) {
+        this.textEl.setAttribute("text", "value", "Block");
+      } else {
+        this.textEl.setAttribute("text", "value", "Hide");
+      }
+    };
     NAF.utils.getNetworkedEntity(this.el).then(networkedEl => {
       this.owner = networkedEl.components.networked.data.owner;
     });
+    this.onScopeChange();
   },
 
   play() {
     this.el.object3D.addEventListener("interact", this.onClick);
+    this.el.sceneEl.addEventListener("stateadded", this.onScopeChange);
+    this.el.sceneEl.addEventListener("stateremoved", this.onScopeChange);
   },
 
   pause() {
     this.el.object3D.removeEventListener("interact", this.onClick);
+    this.el.sceneEl.removeEventListener("stateremoved", this.onScopeChange);
   },
 
   block(clientId) {

--- a/src/components/immers/immers-visible-if-permitted.js
+++ b/src/components/immers/immers-visible-if-permitted.js
@@ -1,0 +1,19 @@
+AFRAME.registerComponent("immers-visible-if-permitted", {
+  schema: {
+    type: "string",
+    oneOf: ["viewFriends", "postLocation", "viewPrivate", "creative", "addFriends", "addBlocks", "destructive"]
+  },
+  init() {
+    this.updateVisibility = this.updateVisibility.bind(this);
+    this.el.sceneEl.addEventListener("stateadded", this.updateVisibility);
+    this.el.sceneEl.addEventListener("stateremoved", this.updateVisibility);
+    this.updateVisibility();
+  },
+  updateVisibility() {
+    this.el.object3D.visible = this.el.sceneEl.states.includes(`immers-scope-${this.data}`);
+  },
+  remove() {
+    this.el.sceneEl.removeEventListener("stateadded", this.updateVisibility);
+    this.el.sceneEl.removeEventListener("stateremoved", this.updateVisibility);
+  }
+});

--- a/src/components/immers/index.js
+++ b/src/components/immers/index.js
@@ -6,3 +6,4 @@ import "./monetization-invisible";
 import "./monetization-required";
 import "./monetization-interactable";
 import "./monetization-networked";
+import "./immers-visible-if-permitted";

--- a/src/hub.html
+++ b/src/hub.html
@@ -189,7 +189,7 @@
                                             <a-entity text="value:Follow; width:1.6; align:center;" text-raycast-hack position="0 0 0.001"></a-entity>
                                         </a-entity>
                                         <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" block-button position="0 0 .35">
-                                            <a-entity text="value:Block; width:2.5; align:center;" text-raycast-hack position="0 0 0.001"></a-entity>
+                                            <a-entity text="value:Hide; width:2.5; align:center;" text-raycast-hack position="0 0 0.001"></a-entity>
                                         </a-entity>
                                         <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" visible-if-permitted="mute_users" mute-button position="0 -0.3 .35" scale="0.8 0.8 0.8">
                                             <a-entity text="value:Mute; width:2.5; align:center;" text-raycast-hack visible-if-permitted="mute_users" position="0 0 0.001"></a-entity>

--- a/src/hub.html
+++ b/src/hub.html
@@ -185,7 +185,7 @@
                                         <a-entity mixin="rounded-button" is-remote-hover-target tags="singleActionButton: true;" position="0.45 0.675 0.35" class="avatar-volume-up-button">
                                             <a-entity text="value: +; anchor: center; align: center; color: #ccc; letterSpacing: 4; width: 2.5;" text-raycast-hack position="0 0 0.001" scale="0.85 0.85 0.85"></a-entity>
                                         </a-entity>
-                                        <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" immers-follow-button position="0 0.3 .35">
+                                        <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" immers-follow-button immers-visible-if-permitted="addFriends" position="0 0.3 .35">
                                             <a-entity text="value:Follow; width:1.6; align:center;" text-raycast-hack position="0 0 0.001"></a-entity>
                                         </a-entity>
                                         <a-entity is-remote-hover-target tags="singleActionButton:true;" mixin="rounded-text-button" block-button position="0 0 .35">
@@ -855,24 +855,26 @@
                         position="0 0.225 0"
                         class="video-snap-button"
                     ></a-entity>
-                    <a-entity mixin="rounded-share-text-action-button ui" is-remote-hover-target tags="singleActionButton: true; isHoverMenuChild: true;" immers-share-button="public" visibility-on-content-types="contentTypes: video/mp4; contentSubtype: video-camera; visible: true;" position="-0.23 0.285 0.001">
-                      <a-entity text=" value:share\npublicly; width:1.25; align:center;" text-raycast-hack position="0.05 0 0.02"></a-entity>
-                      <a-entity
-                          sprite
-                          icon-button="image: immers-action.png; hoverImage: immers-action.png;"
-                          scale="0.075 0.075 0.075"
-                          position="-0.145 0.005 0.001"
-                      ></a-entity>
+                    <a-entity immers-visible-if-permitted="creative">
+                      <a-entity mixin="rounded-share-text-action-button ui" is-remote-hover-target tags="singleActionButton: true; isHoverMenuChild: true;" immers-share-button="public" visibility-on-content-types="contentTypes: video/mp4; contentSubtype: video-camera; visible: true;" position="-0.23 0.285 0.001">
+                        <a-entity text=" value:share\npublicly; width:1.25; align:center;" text-raycast-hack position="0.05 0 0.02"></a-entity>
+                        <a-entity
+                            sprite
+                            icon-button="image: immers-action.png; hoverImage: immers-action.png;"
+                            scale="0.075 0.075 0.075"
+                            position="-0.145 0.005 0.001"
+                        ></a-entity>
+                      </a-entity>
+                      <a-entity mixin="rounded-share-text-action-button ui" is-remote-hover-target tags="singleActionButton: true; isHoverMenuChild: true;" immers-share-button="friends" visibility-on-content-types="contentTypes: video/mp4; contentSubtype: video-camera; visible: true;" position="0.23 0.285 0.001">
+                        <a-entity text=" value:share\nwith friends; width:1.25; align:center;" text-raycast-hack position="0.05 0 0.02"></a-entity>
+                        <a-entity
+                            sprite
+                            icon-button="image: immers-action.png; hoverImage: immers-action.png;"
+                            scale="0.075 0.075 0.075"
+                            position="-0.145 0.005 0.001"
+                        ></a-entity>
+                      </a-entity>
                     </a-entity>
-                    <a-entity mixin="rounded-share-text-action-button ui" is-remote-hover-target tags="singleActionButton: true; isHoverMenuChild: true;" immers-share-button="friends" visibility-on-content-types="contentTypes: video/mp4; contentSubtype: video-camera; visible: true;" position="0.23 0.285 0.001">
-                      <a-entity text=" value:share\nwith friends; width:1.25; align:center;" text-raycast-hack position="0.05 0 0.02"></a-entity>
-                      <a-entity
-                          sprite
-                          icon-button="image: immers-action.png; hoverImage: immers-action.png;"
-                          scale="0.075 0.075 0.075"
-                          position="-0.145 0.005 0.001"
-                      ></a-entity>
-                  </a-entity>
                     <a-entity class="video-time-label" text="value: 0; anchor: center; align: center; color: #aaa;" text-raycast-hack position="0 -0.24 0" scale="0.75 0.75 0.75"></a-entity>
                     <a-entity class="video-volume-label" text="value: 0%; anchor: center; align: center; color: #ccc; letterSpacing: 4;" text-raycast-hack position="0.0 0.14 0.0015" scale="1.25 1.25 1.25"></a-entity>
                     <a-entity
@@ -961,6 +963,7 @@
 
             <template id="photo-hover-menu">
                 <a-entity class="ui interactable-ui hover-container" visible="false">
+                  <a-entity immers-visible-if-permitted="creative">
                     <a-entity mixin="rounded-share-text-action-button ui" is-remote-hover-target tags="singleActionButton: true; isHoverMenuChild: true;" immers-share-button="public" position="-0.23 0.285 0.001">
                         <a-entity text=" value:share\npublicly; width:1.25; align:center;" text-raycast-hack position="0.05 0 0.02"></a-entity>
                         <a-entity
@@ -979,6 +982,7 @@
                             position="-0.145 0.005 0.001"
                         ></a-entity>
                     </a-entity>
+                  </a-entity>
                 </a-entity>
             </template>
 

--- a/src/hub.js
+++ b/src/hub.js
@@ -191,8 +191,6 @@ if (isEmbed && !qs.get("embed_token")) {
   throw new Error("no embed token");
 }
 
-immers.auth(store);
-
 THREE.Object3D.DefaultMatrixAutoUpdate = false;
 
 import "./components/owned-object-limiter";

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,10 @@ import { HomePage } from "./react-components/home/HomePage";
 import { AuthContextProvider } from "./react-components/auth/AuthContext";
 import "./react-components/styles/global.scss";
 import { ThemeProvider } from "./react-components/styles/theme";
+import { catchToken } from "./utils/immers/authUtils";
+
+// homepage is used as redirectURI in popup OAuth flow (because using the hub uri causes duplicate session disconnect)
+catchToken();
 
 registerTelemetry("/home", "Hubs Home Page");
 

--- a/src/react-components/room/AvatarSettingsContent.js
+++ b/src/react-components/room/AvatarSettingsContent.js
@@ -5,6 +5,7 @@ import styles from "./AvatarSettingsContent.scss";
 import { TextInputField } from "../input/TextInputField";
 import { Column } from "../layout/Column";
 import { FormattedMessage } from "react-intl";
+import { ImmersPermissionUpgrade } from "./ImmersReact";
 
 export function AvatarSettingsContent({
   displayName,
@@ -41,6 +42,9 @@ export function AvatarSettingsContent({
         </Button>
       </div>
       <AcceptButton preset="accept" type="submit" />
+      <ImmersPermissionUpgrade scope="creative" role="modAdditive">
+        Changes will only apply in this Immer. Need permission to update profile or save new avatars
+      </ImmersPermissionUpgrade>
     </Column>
   );
 }

--- a/src/react-components/room/ImmersFeedSidebarContainer.js
+++ b/src/react-components/room/ImmersFeedSidebarContainer.js
@@ -11,7 +11,7 @@ import { ReactComponent as LocalIcon } from "../icons/Home.svg";
 import { IconButton } from "../input/IconButton";
 import styles from "./ChatSidebar.scss";
 
-export const ImmersFeedContext = createContext({ messageGroups: [], sendMessage: () => {} });
+export const ImmersFeedContext = createContext({ messageGroups: [], sendMessage: () => {}, permissions: [] });
 
 let uniqueMessageId = 0;
 
@@ -54,7 +54,7 @@ function updateMessageGroups(messageGroups, newMessage) {
   }
 }
 
-export function ImmersFeedContextProvider({ messageDispatch, children, permissions, reAuthorize }) {
+export function ImmersFeedContextProvider({ messageDispatch, children, permissions = [], reAuthorize }) {
   const [messageGroups, setMessageGroups] = useState([]);
   const [unreadMessages, setUnreadMessages] = useState(false);
   const [audience, setAudience] = useState("public");

--- a/src/react-components/room/ImmersReact.js
+++ b/src/react-components/room/ImmersReact.js
@@ -33,9 +33,9 @@ export function ImmerLink({ place }) {
     ) {
       placeUrl = null;
     } else {
-      const search = new URLSearchParams(url.search);
-      search.set("me", window.APP.store.state.profile.handle);
-      url.search = search.toString();
+      const hashParams = new URLSearchParams();
+      hashParams.set("me", window.APP.store.state.profile.handle);
+      url.hash = hashParams.toString();
       placeUrl = url.toString();
     }
   } catch (ignore) {
@@ -86,24 +86,25 @@ ImmersChatMessage.propTypes = {
   context: PropTypes.object
 };
 
-export function ImmersImageIcon({ src, title }) {
+export function ImmersImageIcon({ src, title, button }) {
   return (
-    <span className={styles.imageIconWrapper}>
+    <span className={classNames({ [styles.imageIconWrapper]: true, [styles.buttonIcon]: button })}>
       {src && <img className={styles.imageIcon} src={proxiedUrlFor(src)} title={title} />}
     </span>
   );
 }
 ImmersImageIcon.propTypes = {
   src: PropTypes.string,
-  title: PropTypes.string
+  title: PropTypes.string,
+  button: PropTypes.bool
 };
 
 export function ImmersFriendIcon() {
   return <ImmersImageIcon src={immersLogo} title={"Immers Space Friend"} />;
 }
 
-export function ImmersIcon() {
-  return <ImmersImageIcon src={immersLogo} />;
+export function ImmersIcon(props) {
+  return <ImmersImageIcon src={immersLogo} {...props} />;
 }
 
 export function ImmersAvatarIcon({ avi }) {

--- a/src/react-components/room/ImmersReact.js
+++ b/src/react-components/room/ImmersReact.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import { getMessageComponent } from "./ChatSidebar";
@@ -8,6 +8,7 @@ import { FormattedRelativeTime } from "react-intl";
 import { proxiedUrlFor } from "../../utils/media-url-utils";
 import immersLogo from "../../assets/images/immers_logo.png";
 import merge from "deepmerge";
+import { ImmersFeedContext } from "./ImmersFeedSidebarContainer";
 
 function proxyAndGetMessageComponent(message) {
   // media urls need proxy to pass CSP & CORS
@@ -147,3 +148,37 @@ export function ImmersMoreHistoryButton() {
     )
   );
 }
+
+export function ImmersPermissionUpgrade({ scope, role, children }) {
+  const { permissions } = useContext(ImmersFeedContext);
+  if (permissions.includes(scope)) {
+    return null;
+  }
+  return (
+    <div className={styles.permissions}>
+      <ImmersIcon />
+      <p>
+        {children}. <ImmersPermissionUpgradeButton role={role} />
+      </p>
+    </div>
+  );
+}
+
+ImmersPermissionUpgrade.propTypes = {
+  children: PropTypes.node,
+  scope: PropTypes.string,
+  role: PropTypes.string
+};
+
+export function ImmersPermissionUpgradeButton({ role }) {
+  const { reAuthorize } = useContext(ImmersFeedContext);
+  return (
+    <a href="#" className={styles.permissionsButton} onClick={() => reAuthorize(role)}>
+      Reload &amp; change
+    </a>
+  );
+}
+
+ImmersPermissionUpgradeButton.propTypes = {
+  role: PropTypes.string
+};

--- a/src/react-components/room/ImmersReact.scss
+++ b/src/react-components/room/ImmersReact.scss
@@ -6,6 +6,11 @@
   overflow: hidden;
 }
 
+:local(.button-icon) {
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+
 :local(.image-icon) {
   width: 20px;
 }

--- a/src/react-components/room/ImmersReact.scss
+++ b/src/react-components/room/ImmersReact.scss
@@ -47,3 +47,17 @@
   padding-top: 5px;
   font-size: theme.$font-size-sm;
 }
+
+:local(.permissions) {
+  display: flex;
+  font-size: theme.$font-size-sm;
+  padding-left: 5px;
+
+  p {
+    padding-left: 5px;
+  }
+}
+
+:local(.permissions-button) {
+  padding-right: 5px;
+}

--- a/src/react-components/room/PeopleSidebar.js
+++ b/src/react-components/room/PeopleSidebar.js
@@ -14,7 +14,7 @@ import { ReactComponent as VolumeHighIcon } from "../icons/VolumeHigh.svg";
 import { ReactComponent as VolumeMutedIcon } from "../icons/VolumeMuted.svg";
 import { List, ButtonListItem } from "../layout/List";
 import { FormattedMessage, useIntl } from "react-intl";
-import { ImmerLink, ImmersAvatarIcon, ImmersFriendIcon } from "./ImmersReact";
+import { ImmerLink, ImmersAvatarIcon, ImmersFriendIcon, ImmersPermissionUpgrade } from "./ImmersReact";
 
 function getDeviceLabel(ctx, intl) {
   if (ctx) {
@@ -167,6 +167,11 @@ export function PeopleSidebar({ people, onSelectPerson, onClose, showMuteAll, on
             </ButtonListItem>
           );
         })}
+        <li>
+          <ImmersPermissionUpgrade scope="viewFriends" role="friends">
+            Need permission to load friends
+          </ImmersPermissionUpgrade>
+        </li>
       </List>
     </Sidebar>
   );

--- a/src/react-components/room/RoomEntryModal.js
+++ b/src/react-components/room/RoomEntryModal.js
@@ -13,12 +13,15 @@ import styleUtils from "../styles/style-utils.scss";
 import { useCssBreakpoints } from "react-use-css-breakpoints";
 import { Column } from "../layout/Column";
 import { FormattedMessage } from "react-intl";
+import { ImmersIcon } from "./ImmersReact";
 
 export function RoomEntryModal({
   appName,
   logoSrc,
   className,
   roomName,
+  showLoginToImmers,
+  onLoginToImmers,
   showJoinRoom,
   onJoinRoom,
   showEnterOnDevice,
@@ -48,7 +51,15 @@ export function RoomEntryModal({
           <p>{roomName}</p>
         </div>
         <Column center className={styles.buttons}>
-          {showJoinRoom && (
+          {showLoginToImmers && (
+            <Button preset="basic" onClick={onLoginToImmers}>
+              <ImmersIcon button={true} />
+              <span>
+                <FormattedMessage id="room-entry-modal.login-to-immers-button" defaultMessage="Immers Login" />
+              </span>
+            </Button>
+          )}
+          {!showLoginToImmers && showJoinRoom && (
             <Button preset="accent4" onClick={onJoinRoom}>
               <EnterIcon />
               <span>
@@ -56,7 +67,7 @@ export function RoomEntryModal({
               </span>
             </Button>
           )}
-          {showEnterOnDevice && (
+          {!showLoginToImmers && showEnterOnDevice && (
             <Button preset="accent5" onClick={onEnterOnDevice}>
               <VRIcon />
               <span>

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -146,6 +146,8 @@ class UIRoot extends Component {
     friends: PropTypes.array,
     handle: PropTypes.string,
     immersScopes: PropTypes.array,
+    isImmersConnected: PropTypes.bool,
+    startImmersAuth: PropTypes.func,
     isMonetized: PropTypes.bool,
     sessionId: PropTypes.string,
     subscriptions: PropTypes.object,
@@ -175,7 +177,8 @@ class UIRoot extends Component {
 
   static defaultProps = {
     friends: [],
-    immersScopes: []
+    immersScopes: [],
+    isImmersConnected: false
   };
 
   state = {
@@ -807,6 +810,8 @@ class UIRoot extends Component {
           appName={configs.translation("app-name")}
           logoSrc={configs.image("logo")}
           roomName={this.props.hub.name}
+          showLoginToImmers={!this.props.isImmersConnected}
+          onLoginToImmers={this.props.startImmersAuth}
           showJoinRoom={!this.state.waitingOnAudio && canEnter}
           onJoinRoom={() => {
             if (promptForNameAndAvatarBeforeEntry || !this.props.forcedVREntryType) {
@@ -1574,7 +1579,9 @@ class UIRoot extends Component {
                       </>
                     )}
                     <ChatToolbarButtonContainer onClick={() => this.toggleSidebar("chat")} />
-                    <ImmersFeedToolbarButtonContainer onClick={() => this.toggleSidebar("feed")} />
+                    {this.props.isImmersConnected && (
+                      <ImmersFeedToolbarButtonContainer onClick={() => this.toggleSidebar("feed")} />
+                    )}
                     {entered &&
                       isMobileVR && (
                         <ToolbarButton

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -145,6 +145,7 @@ class UIRoot extends Component {
     presences: PropTypes.object,
     friends: PropTypes.array,
     handle: PropTypes.string,
+    immersScopes: PropTypes.array,
     isMonetized: PropTypes.bool,
     sessionId: PropTypes.string,
     subscriptions: PropTypes.object,
@@ -173,7 +174,8 @@ class UIRoot extends Component {
   };
 
   static defaultProps = {
-    friends: []
+    friends: [],
+    immersScopes: []
   };
 
   state = {
@@ -1649,7 +1651,11 @@ function UIRootHooksWrapper(props) {
 
   return (
     <ChatContextProvider messageDispatch={props.messageDispatch}>
-      <ImmersFeedContextProvider messageDispatch={props.immersMessageDispatch}>
+      <ImmersFeedContextProvider
+        messageDispatch={props.immersMessageDispatch}
+        permissions={props.immersScopes}
+        reAuthorize={props.immersReAuth}
+      >
         <ObjectListProvider scene={props.scene}>
           <UIRoot breakpoint={breakpoint} {...props} />
         </ObjectListProvider>
@@ -1662,7 +1668,9 @@ UIRootHooksWrapper.propTypes = {
   scene: PropTypes.object.isRequired,
   messageDispatch: PropTypes.object,
   store: PropTypes.object.isRequired,
-  immersMessageDispatch: PropTypes.object
+  immersMessageDispatch: PropTypes.object,
+  immersScopes: PropTypes.array,
+  immersReAuth: PropTypes.func
 };
 
 export default UIRootHooksWrapper;

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -172,6 +172,10 @@ class UIRoot extends Component {
     breakpoint: PropTypes.string
   };
 
+  static defaultProps = {
+    friends: []
+  };
+
   state = {
     enterInVR: false,
     entered: false,

--- a/src/storage/store.js
+++ b/src/storage/store.js
@@ -63,7 +63,8 @@ export const SCHEMA = {
         token: { type: ["null", "string"] },
         email: { type: ["null", "string"] },
         immerToken: { type: ["null", "string"] },
-        immerHome: { type: ["null", "string"] }
+        immerHome: { type: ["null", "string"] },
+        immerScopes: { type: ["null", "array"] }
       }
     },
 

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -17,6 +17,7 @@ let isAdmin = false;
   "GA_TRACKING_ID",
   "SHORTLINK_DOMAIN",
   "IMMERS_SERVER",
+  "IMMERS_SCOPE",
   "BASE_ASSETS_PATH"
 ].forEach(x => {
   const el = document.querySelector(`meta[name='env:${x.toLowerCase()}']`);

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -345,6 +345,7 @@ export async function initialize(store, scene, remountUI, messageDispatch, creat
       immerScopes: authorizedScopes
     }
   });
+  authorizedScopes.forEach(scope => hubScene.addState(`immers-scope-${scope}`));
   const immerSocket = io(homeImmer, {
     transportOptions: {
       polling: {

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -225,7 +225,7 @@ export async function getFriends(actorObj) {
     }
   });
   if (!response.ok) {
-    throw new Error("Unable to fech friends");
+    throw new Error(`Unable to fech friends: ${response.statusText}`);
   }
   return response.json();
 }
@@ -381,9 +381,14 @@ export async function initialize(store, scene, remountUI, messageDispatch, creat
   const updateFriends = async () => {
     if (store.state.profile.id) {
       const profile = store.state.profile;
-      friendsCol = await getFriends(profile);
-      activities.friends = friendsCol.orderedItems;
-      remountUI({ friends: friendsCol.orderedItems.filter(act => act.type !== "Reject"), handle: profile.handle });
+      try {
+        friendsCol = await getFriends(profile);
+        activities.friends = friendsCol.orderedItems;
+        remountUI({ friends: friendsCol.orderedItems.filter(act => act.type !== "Reject"), handle: profile.handle });
+      } catch (err) {
+        console.warn(err.message);
+        remountUI({ friends: [], handle: profile.handle });
+      }
       // update follow button for new friends
       const players = window.APP.componentRegistry["player-info"];
       players?.forEach(infoComp => setFriendState(infoComp.data.immersId, infoComp.el));

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -8,7 +8,7 @@ import Activities from "./immers/activities";
 const localImmer = configs.IMMERS_SERVER;
 // immer can set a requested scope, but user can override
 const preferredScope = configs.IMMERS_SCOPE;
-console.log("immers.space client v0.7.1");
+console.log("immers.space client v1.1.0");
 const jsonldMime = "application/activity+json";
 // avoid race between auth and initialize code
 let resolveAuth;

--- a/src/utils/immers/activities.js
+++ b/src/utils/immers/activities.js
@@ -5,6 +5,7 @@ export default class Activities {
     this.localImmer = localImmer;
     this.homeImmer = null;
     this.token = null;
+    this.authorizedScopes = null;
     this.actor = null;
     this.place = null;
     this.nextInboxPage = null;

--- a/src/utils/immers/authUtils.js
+++ b/src/utils/immers/authUtils.js
@@ -1,0 +1,32 @@
+export const allScopes = [
+  "viewProfile",
+  "viewPublic",
+  "viewFriends",
+  "postLocation",
+  "viewPrivate",
+  "creative",
+  "addFriends",
+  "addBlocks",
+  "destructive"
+];
+
+export function catchToken() {
+  const hashParams = new URLSearchParams(window.location.hash.substring(1));
+  if (hashParams.has("access_token")) {
+    // not safe to update store here, will be saved later in initialize()
+    const token = hashParams.get("access_token");
+    const homeImmer = hashParams.get("issuer");
+    const authorizedScopes = hashParams.get("scope")?.split(" ") || [];
+    window.location.hash = "";
+    // If this is an oauth popup, pass the results back up and close
+    // todo check origin
+    if (window.opener) {
+      window.opener.postMessage({
+        type: "ImmersAuth",
+        token,
+        homeImmer,
+        authorizedScopes
+      });
+    }
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -633,6 +633,7 @@ module.exports = async (env, argv) => {
           GA_TRACKING_ID: process.env.GA_TRACKING_ID,
           POSTGREST_SERVER: process.env.POSTGREST_SERVER,
           IMMERS_SERVER: process.env.IMMERS_SERVER,
+          IMMERS_SCOPE: process.env.IMMERS_SCOPE,
           APP_CONFIG: appConfig
         })
       })


### PR DESCRIPTION
Integration with the new authorizatoin scopes from immers-space/immers#29 

* Ensure we fail gracefully when requests are denied
  * Default friends list to empty array to UI doesn't crash if friends list blocked
  * Skip over activitypub avatar creation if not permitted to avoid an unhandle promise exception
  * Most other actions are left alone and will just receive a 403 and handle it
* Update UX to inform users when an action or info isn't available
  * Immers chat posting, friends list, and profile updates show an explanatory message and prompt to re-login
  * Add friend & share selfie buttons are just hidden (couldn't figure a clean way to do the explain&prompt pattern in the 3D assets)
  * Block button label reverts to "Hide"
* Add a configuration option for immers to choose their preferred role to request (will be default selection in dialog)

Update 5/7 - I finished the OAuth popup work and it included a couple bugfixes for the scopes, so I just merged it in to this PR
* Change from redirect-based OAuth to a popup window
* Update react UX to show login prompt and hide immers chat panel before login
* Refactor auth & initialization flow to work with popup
* Change pass-your-handle-through-links to use hash because we no longer update the query during redirect so it would just get stuck in your URL and potentially shared
* Prefill handle in login form when renewing expired token on remote immer