### PR TITLE
Onboarding flow and ux cleanup

### DIFF
--- a/src/hub.html
+++ b/src/hub.html
@@ -326,6 +326,7 @@
                         <a-entity class="freeze-menu" visibility-while-frozen="withinDistance: 100; withPermission: spawn_and_move_media">
                             <a-entity
                                 mixin="rounded-text-action-button"
+                                visible-if-permitted="pin_objects"
                                 is-remote-hover-target
                                 tags="singleActionButton:true"
                                 pin-networked-object-button="tipSelector:.pin-button-tip; labelSelector:.pin-button-label;"

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -503,14 +503,16 @@ class MediaBrowserContainer extends Component {
         entries.length > 0 ||
         !showEmptyStringOnNoResult ? (
           <>
-            {urlSource === "avatars" && (
-              <CreateTile
-                type="avatar"
-                onClick={this.onCreateAvatar}
-                label={<FormattedMessage id="media-browser.create-avatar" defaultMessage="Create Avatar" />}
-              />
-            )}
+            {this.props.hubChannel.signedIn &&
+              urlSource === "avatars" && (
+                <CreateTile
+                  type="avatar"
+                  onClick={this.onCreateAvatar}
+                  label={<FormattedMessage id="media-browser.create-avatar" defaultMessage="Create Avatar" />}
+                />
+              )}
             {urlSource === "scenes" &&
+              this.props.hubChannel.signedIn &&
               configs.feature("enable_spoke") && (
                 <CreateTile
                   as="a"
@@ -559,6 +561,10 @@ class MediaBrowserContainer extends Component {
                 onCopy = e => this.handleCopyAvatar(e, entry);
               } else if (isScene) {
                 onCopy = e => this.handleCopyScene(e, entry);
+              }
+
+              if (!this.props.hubChannel.signedIn) {
+                onCopy = null;
               }
 
               return (

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -370,8 +370,7 @@ class MediaBrowserContainer extends Component {
     const urlSource = this.getUrlSource(searchParams);
     const isSceneApiType = urlSource === "scenes";
     const isFavorites = urlSource === "favorites";
-    const showCustomOption =
-      !isFavorites && (!isSceneApiType || this.props.hubChannel.canOrWillIfCreator("update_hub"));
+    const showCustomOption = !isFavorites && this.props.hubChannel.canOrWillIfCreator("update_hub");
     const entries = (this.state.result && this.state.result.entries) || [];
     const hideSearch = urlSource === "favorites";
     const showEmptyStringOnNoResult = urlSource !== "avatars" && urlSource !== "scenes";

--- a/src/react-components/media-browser.js
+++ b/src/react-components/media-browser.js
@@ -370,7 +370,8 @@ class MediaBrowserContainer extends Component {
     const urlSource = this.getUrlSource(searchParams);
     const isSceneApiType = urlSource === "scenes";
     const isFavorites = urlSource === "favorites";
-    const showCustomOption = !isFavorites && this.props.hubChannel.canOrWillIfCreator("update_hub");
+    const showCustomOption =
+      !isFavorites && (!isSceneApiType || this.props.hubChannel.canOrWillIfCreator("update_hub"));
     const entries = (this.state.result && this.state.result.entries) || [];
     const hideSearch = urlSource === "favorites";
     const showEmptyStringOnNoResult = urlSource !== "avatars" && urlSource !== "scenes";

--- a/src/react-components/room/ImmersReact.js
+++ b/src/react-components/room/ImmersReact.js
@@ -151,8 +151,8 @@ export function ImmersMoreHistoryButton() {
 }
 
 export function ImmersPermissionUpgrade({ scope, role, children }) {
-  const { permissions } = useContext(ImmersFeedContext);
-  if (permissions.includes(scope)) {
+  const { permissions, reAuthorize } = useContext(ImmersFeedContext);
+  if (permissions.includes(scope) || !reAuthorize) {
     return null;
   }
   return (
@@ -173,6 +173,10 @@ ImmersPermissionUpgrade.propTypes = {
 
 export function ImmersPermissionUpgradeButton({ role }) {
   const { reAuthorize } = useContext(ImmersFeedContext);
+  if (!reAuthorize) {
+    // initial auth has not occurred
+    return null;
+  }
   return (
     <a href="#" className={styles.permissionsButton} onClick={() => reAuthorize(role)}>
       Reload &amp; change

--- a/src/react-components/room/MediaTiles.js
+++ b/src/react-components/room/MediaTiles.js
@@ -233,6 +233,7 @@ export function MediaTile({ entry, processThumbnailUrl, onClick, onEdit, onShowS
           </TileAction>
         )}
         {entry.type === "avatar_listing" &&
+          onCopy &&
           entry.allow_remixing && (
             <TileAction
               title={intl.formatMessage({
@@ -245,6 +246,7 @@ export function MediaTile({ entry, processThumbnailUrl, onClick, onEdit, onShowS
             </TileAction>
           )}
         {entry.type === "scene_listing" &&
+          onCopy &&
           entry.allow_remixing && (
             <TileAction
               title={intl.formatMessage({

--- a/src/react-components/room/RoomEntryModal.js
+++ b/src/react-components/room/RoomEntryModal.js
@@ -30,6 +30,7 @@ export function RoomEntryModal({
   onSpectate,
   showOptions,
   onOptions,
+  showRoomFull,
   showMonetizationRequired,
   showMonetized,
   ...rest
@@ -52,14 +53,23 @@ export function RoomEntryModal({
         </div>
         <Column center className={styles.buttons}>
           {showLoginToImmers && (
-            <Button preset="basic" onClick={onLoginToImmers}>
-              <ImmersIcon button={true} />
-              <span>
-                <FormattedMessage id="room-entry-modal.login-to-immers-button" defaultMessage="Immers Login" />
-              </span>
-            </Button>
+            <>
+              <Button preset="basic" onClick={onLoginToImmers}>
+                <ImmersIcon button={true} />
+                <span>
+                  <FormattedMessage id="room-entry-modal.login-to-immers-button" defaultMessage="Immers Login" />
+                </span>
+              </Button>
+              <Button preset="primary" onClick={onLoginToImmers} className="registration">
+                {/* <ImmersIcon button={true} /> */}
+                <span>
+                  <FormattedMessage id="room-entry-modal.immers-register-button" defaultMessage="Sign up" />
+                </span>
+              </Button>
+              <p>Login or create a free account to join the room</p>
+            </>
           )}
-          {!showLoginToImmers && showJoinRoom && (
+          {showJoinRoom && (
             <Button preset="accent4" onClick={onJoinRoom}>
               <EnterIcon />
               <span>
@@ -67,7 +77,7 @@ export function RoomEntryModal({
               </span>
             </Button>
           )}
-          {!showLoginToImmers && showEnterOnDevice && (
+          {showEnterOnDevice && (
             <Button preset="accent5" onClick={onEnterOnDevice}>
               <VRIcon />
               <span>
@@ -84,21 +94,26 @@ export function RoomEntryModal({
             </Button>
           )}
           <div className={styles.webmon}>
-            {!showJoinRoom && <p>This space has no more free slots available.</p>}
-            <WMIcon />
             {showMonetized && (
-              <div>
-                Thanks for paying! You can join this space even if it is full. Search for this icon in the space to find
-                other premium features.
-              </div>
+              <>
+                <WMIcon />
+                <p>
+                  Thanks for paying! {showRoomFull && <span>You can join this space even though it is full.</span>}{" "}
+                  Search for this icon in the space to find other premium features.
+                </p>
+              </>
             )}
             {showMonetizationRequired && (
-              <div>
-                <a href="https://web.immers.space/monetization-required/" target="_blank" rel="noopener">
-                  Sign up for Web Monetization
-                </a>{" "}
-                to unlock premium features and join spaces even when they are full.
-              </div>
+              <>
+                <WMIcon />
+                <p>
+                  This space has no more free slots available.{" "}
+                  <a href="https://web.immers.space/monetization-required/" target="_blank" rel="noopener noreferrer">
+                    Sign up for Web Monetization
+                  </a>{" "}
+                  to join anyway.
+                </p>
+              </>
             )}
           </div>
 

--- a/src/react-components/room/RoomEntryModal.js
+++ b/src/react-components/room/RoomEntryModal.js
@@ -66,7 +66,7 @@ export function RoomEntryModal({
                   <FormattedMessage id="room-entry-modal.immers-register-button" defaultMessage="Sign up" />
                 </span>
               </Button>
-              <p>Login or create a free account to join the room</p>
+              <p>Login or create a free account to join this space</p>
             </>
           )}
           {showJoinRoom && (

--- a/src/react-components/room/RoomEntryModal.scss
+++ b/src/react-components/room/RoomEntryModal.scss
@@ -10,6 +10,10 @@
   @media(min-width: theme.$breakpoint-lg) and (min-height: theme.$breakpoint-vr) {
     padding: 24px;
   }
+  p {
+    font-size: theme.$font-size-sm;
+    max-width: 275px;
+  }
 }
 
 :local(.logo-container) {
@@ -53,7 +57,7 @@
 
 :local(.webmon) {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
   svg {
     flex-shrink: 0;

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1126,7 +1126,7 @@ class UIRoot extends Component {
               }
             : {
                 id: "sign-in",
-                label: <FormattedMessage id="more-menu.sign-in" defaultMessage="Sign In" />,
+                label: <FormattedMessage id="more-menu.sign-in" defaultMessage="Admin Sign In" />,
                 icon: EnterIcon,
                 onClick: () => this.showContextualSignInDialog()
               },
@@ -1146,7 +1146,7 @@ class UIRoot extends Component {
             icon: AvatarIcon,
             onClick: () => this.setSidebar("profile")
           },
-          {
+          this.state.signedIn  && {
             id: "favorite-rooms",
             label: <FormattedMessage id="more-menu.favorite-rooms" defaultMessage="Favorite Rooms" />,
             icon: FavoritesIcon,
@@ -1185,14 +1185,14 @@ class UIRoot extends Component {
               icon: InviteIcon,
               onClick: () => this.props.scene.emit("action_invite")
             },
-          this.isFavorited()
+          this.state.signedIn && this.isFavorited()
             ? {
                 id: "unfavorite-room",
                 label: <FormattedMessage id="more-menu.unfavorite-room" defaultMessage="Unfavorite Room" />,
                 icon: StarIcon,
                 onClick: () => this.toggleFavorited()
               }
-            : {
+            : this.state.signedIn && {
                 id: "favorite-room",
                 label: <FormattedMessage id="more-menu.favorite-room" defaultMessage="Favorite Room" />,
                 icon: StarOutlineIcon,

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -801,8 +801,10 @@ class UIRoot extends Component {
   renderEntryStartPanel = () => {
     const { hasAcceptedProfile, hasChangedName } = this.props.store.state.activity;
     const promptForNameAndAvatarBeforeEntry = this.props.hubIsBound ? !hasAcceptedProfile : !hasChangedName;
+    const pageIsMonetized = !!document.querySelector("meta[name=monetization]");
+    const showLogin = !this.props.isImmersConnected;
     // monetized users can bypass room limit
-    const canEnter = !this.props.entryDisallowed || this.props.isMonetized;
+    const canEnter = this.props.isImmersConnected && (!this.props.entryDisallowed || this.props.isMonetized);
     // TODO: What does onEnteringCanceled do?
     return (
       <>
@@ -810,7 +812,7 @@ class UIRoot extends Component {
           appName={configs.translation("app-name")}
           logoSrc={configs.image("logo")}
           roomName={this.props.hub.name}
-          showLoginToImmers={!this.props.isImmersConnected}
+          showLoginToImmers={showLogin}
           onLoginToImmers={this.props.startImmersAuth}
           showJoinRoom={!this.state.waitingOnAudio && canEnter}
           onJoinRoom={() => {
@@ -830,7 +832,7 @@ class UIRoot extends Component {
           }}
           showEnterOnDevice={!this.state.waitingOnAudio && canEnter && !isMobileVR}
           onEnterOnDevice={() => this.attemptLink()}
-          showSpectate={!this.state.waitingOnAudio}
+          showSpectate={false}
           onSpectate={() => this.setState({ watching: true })}
           showOptions={this.props.hubChannel.canOrWillIfCreator("update_hub")}
           onOptions={() => {
@@ -840,8 +842,11 @@ class UIRoot extends Component {
               SignInMessages.roomSettings
             );
           }}
-          showMonetizationRequired={!this.props.isMonetized}
-          showMonetized={this.props.isMonetized}
+          showRoomFull={!this.state.waitingOnAudio && !showLogin && this.props.entryDisallowed}
+          showMonetizationRequired={
+            !this.state.waitingOnAudio && pageIsMonetized && !showLogin && !this.props.isMonetized && !canEnter
+          }
+          showMonetized={!this.state.waitingOnAudio && !showLogin && this.props.isMonetized}
         />
         {!this.state.waitingOnAudio && (
           <EntryStartPanel

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1140,7 +1140,7 @@ class UIRoot extends Component {
                 reason: LeaveReason.createRoom
               })
           },
-          {
+          this.props.isImmersConnected && {
             id: "user-profile",
             label: <FormattedMessage id="more-menu.profile" defaultMessage="Change Name & Avatar" />,
             icon: AvatarIcon,

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -1103,7 +1103,7 @@ class UIRoot extends Component {
 
     const renderEntryFlow = (!enteredOrWatching && this.props.hub) || this.isWaitingForAutoExit();
 
-    const canCreateRoom = !configs.feature("disable_room_creation") || configs.isAdmin;
+    const canCreateRoom = !configs.feature("disable_room_creation") || configs.isAdmin();
     const canCloseRoom = this.props.hubChannel && !!this.props.hubChannel.canOrWillIfCreator("close_hub");
     const isModerator = this.props.hubChannel && this.props.hubChannel.canOrWillIfCreator("kick_users") && !isMobileVR;
 

--- a/src/systems/exit-on-blur.js
+++ b/src/systems/exit-on-blur.js
@@ -42,7 +42,7 @@ AFRAME.registerSystem("exit-on-blur", {
   },
 
   onBlur() {
-    if (this.el.isMobile) {
+    if (this.el.isMobile && !this.el.is("immers-authorizing")) {
       clearTimeout(this.exitTimeout);
       this.exitTimeout = setTimeout(this.onTimeout, 30 * 1000);
     }

--- a/src/utils/hub-channel.js
+++ b/src/utils/hub-channel.js
@@ -51,7 +51,8 @@ export default class HubChannel extends EventTarget {
   // Returns true if the current session has the given permission, *or* will get the permission
   // if they sign in and become the creator.
   canOrWillIfCreator(permission) {
-    if (this._getCreatorAssignmentToken() && HUB_CREATOR_PERMISSIONS.includes(permission)) return true;
+    // immers: just show current perms; avoid showing options that aren't available
+    // if (this._getCreatorAssignmentToken() && HUB_CREATOR_PERMISSIONS.includes(permission)) return true;
     return this.can(permission);
   }
 
@@ -105,6 +106,7 @@ export default class HubChannel extends EventTarget {
   setPermissionsFromToken = token => {
     // Note: token is not verified.
     this._permissions = jwtDecode(token);
+    this._permissions.pin_objects = this._permissions.pin_objects && this._signedIn;
     configs.setIsAdmin(this._permissions.postgrest_role === "ret_admin");
     this.dispatchEvent(new CustomEvent("permissions_updated"));
 
@@ -272,8 +274,8 @@ export default class HubChannel extends EventTarget {
       this.channel
         .push("sign_in", { token, creator_assignment_token })
         .receive("ok", ({ perms_token }) => {
-          this.setPermissionsFromToken(perms_token);
           this._signedIn = true;
+          this.setPermissionsFromToken(perms_token);
           resolve();
         })
         .receive("error", err => {

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -298,6 +298,12 @@ export async function auth(store, scope) {
       }
       redirect.search = redirectParams.toString();
       popup = window.open(redirect, "immersLoginPopup", features);
+      if (!popup) {
+        alert("Could not open login window. Please check if popup was blocked and allow it");
+      } else {
+        hubScene?.addState("immers-authorizing");
+        popup.onunload = () => hubScene?.removeState("immers-authorizing");
+      }
     }
   };
 }

--- a/src/utils/immers.js
+++ b/src/utils/immers.js
@@ -251,22 +251,7 @@ export async function auth(store, scope) {
       };
     }
   }
-  // send to token endpoint at local immer, it handles
-  // detecting remote users and sending them on to their home to login
-  const redirect = new URL(`${localImmer}/auth/authorize`);
-  const redirectParams = new URLSearchParams({
-    client_id: place.id,
-    // redirect to homepage to catch token
-    redirect_uri: hubUri.origin,
-    response_type: "token",
-    scope: scope || preferredScope
-  });
-  // users handle may be passed from previous immer or cached but with expired token
-  if (handle || store.state.profile.handle) {
-    // pass to auth to prefill login form
-    redirectParams.set("me", handle || store.state.profile.handle);
-  }
-  redirect.search = redirectParams.toString();
+
   // center the popup
   const width = 730;
   const height = 785;
@@ -293,7 +278,26 @@ export async function auth(store, scope) {
       };
       window.addEventListener("message", handler);
     }),
-    startImmersAuth: () => {
+    startImmersAuth: evt => {
+      // send to token endpoint at local immer, it handles
+      // detecting remote users and sending them on to their home to login
+      const redirect = new URL(`${localImmer}/auth/authorize`);
+      const redirectParams = new URLSearchParams({
+        client_id: place.id,
+        // redirect to homepage to catch token
+        redirect_uri: hubUri.origin,
+        response_type: "token",
+        scope: scope || preferredScope
+      });
+      // users handle may be passed from previous immer or cached but with expired token
+      if (handle || store.state.profile.handle) {
+        // pass to auth to prefill login form
+        redirectParams.set("me", handle || store.state.profile.handle);
+      }
+      if (evt.currentTarget.classList.contains("registration")) {
+        redirectParams.set("tab", "Register");
+      }
+      redirect.search = redirectParams.toString();
       popup = window.open(redirect, "immersLoginPopup", features);
     }
   };


### PR DESCRIPTION
**On boarding flow**

* Before login, only show login prompts
* Add text & additional "sign up" button to clarify new accounts can be created
  * Another PR is coming for the immers repo to make that sign up button lead directly to the registration tab
* Spectate option is removed entirely
* Make monetization prompts contextual
  * Nothing is shown it not monetized and room is not full
  * Explainer/coil sign up prompt shown if room is full and not monetized
  * Thank you is shown if monetized
* Hide avatar settings menu prior to login
* Fix scope upgrade prompt appearing in people menu prior to login

**UX cleanup** - remove UX prompts for actions that require Hubs sign-in if you're not already signed in

* Removed a bunch of room administration related prompts by changing `canOrWillIfCreator` permissions utility. (e.g. kick user, room settings)
* Other items hidden behind a signedIn check
  * Create/copy avatar
  * Create/copy scene
  * Favorite rooms
  * Pin object

** MISC **
* Support custom avatars from URL
* Fix hubs session expiring while filling out registration form
* Fix unnecessary extra avatar/profile updates