### PR TITLE
Redistributable pre-built custom client 🤩 & WebMonetization update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ RUN npm ci
 WORKDIR /usr/src/hubs
 COPY . .
 
+RUN npm run deploy -- --skipCI --noUpload --envPlaceholders
+
 CMD [ "/bin/bash", "dockerdeploy.sh" ]

--- a/dockerdeploy.sh
+++ b/dockerdeploy.sh
@@ -2,9 +2,10 @@
 set -e
 echo "Logging into to hub $hub as $email"
 npm run login -- --host $hub --email $email
-echo "Deploying Immers Space hubs client"
-npm run deploy -- --skipCI
 echo "Updating hubs config for immer $domain"
 # this one reads from env because of issues with dollar sign in payment pointer
 npm run immers-configure
+echo "Deploying Immers Space hubs client"
+npm run deploy -- --noBuild --replacePlaceholders
+
 echo "Done"

--- a/package-lock.json
+++ b/package-lock.json
@@ -38341,9 +38341,9 @@
       }
     },
     "web-monetization-polyfill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/web-monetization-polyfill/-/web-monetization-polyfill-1.0.0.tgz",
-      "integrity": "sha512-lNEkyOtXXdSppvrfTes2/x5LyTCxe7X33at559QC+UM8lHWmEK+6i00iSr78geaM7KCw3paXH16ZR2uFpLEXbw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/web-monetization-polyfill/-/web-monetization-polyfill-2.0.0.tgz",
+      "integrity": "sha512-qrt1PawK4pKtc+aZtu2rxubm8pF25QOcHaU04K3sGMcyqJYr7WwGdXlfK7fA0TkQI0niMO7ZhaqyQ1T2tnVH6A=="
     },
     "web-namespaces": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "three-to-ammo": "github:infinitelee/three-to-ammo",
     "use-clipboard-copy": "^0.1.2",
     "uuid": "^3.2.1",
-    "web-monetization-polyfill": "^1.0.0",
+    "web-monetization-polyfill": "^2.0.0",
     "webrtc-adapter": "^7.7.0",
     "zip-loader": "^1.1.0"
   },

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -8,14 +8,20 @@ import FormData from "form-data";
 import path from "path";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-const skipCI = yargs(hideBin(process.argv)).argv.skipCI;
+const { skipCI, noBuild, noUpload, envPlaceholders, replacePlaceholders } = yargs(hideBin(process.argv)).argv;
+
+let host;
+let token;
 
 if (!existsSync(".ret.credentials")) {
-  console.log("Not logged in, so cannot deploy. To log in, run npm run login.");
-  process.exit(0);
+  if (!noUpload && !envPlaceholders) {
+    console.log("Not logged in, so cannot deploy. To log in, run npm run login.");
+    process.exit(1);
+  }
+} else {
+  ({ host, token } = JSON.parse(readFileSync(".ret.credentials")));
 }
 
-const { host, token } = JSON.parse(readFileSync(".ret.credentials"));
 console.log(`Deploying to ${host}.`);
 const step = ora({ indent: 2 }).start();
 
@@ -34,80 +40,114 @@ const getTs = (() => {
     Authorization: `Bearer ${token}`,
     "Content-Type": "application/json"
   };
-
-  const res = await fetch(`https://${host}/api/ita/configs/hubs`, { headers });
-  const hubsConfigs = await res.json();
-  const buildEnv = {};
-  for (const [k, v] of Object.entries(hubsConfigs.general)) {
-    buildEnv[k.toUpperCase()] = v;
+  let buildEnv = {};
+  let hubsConfigs
+  if (envPlaceholders) {
+    buildEnv = {
+      CORS_PROXY_SERVER: "__IMMERS_PLACEHOLDER_CORS_PROXY_SERVER",
+      BASE_ASSETS_PATH: "__IMMERS_PLACEHOLDER_BASE_ASSETS_PATH",
+      SHORTLINK_DOMAIN: "__IMMERS_PLACEHOLDER_SHORTLINK_DOMAIN",
+      SENTRY_DSN: "__IMMERS_PLACEHOLDER_SENTRY_DSN",
+      GA_TRACKING_ID: "__IMMERS_PLACEHOLDER_GA_TRACKING_ID",
+      RETICULUM_SERVER: "__IMMERS_PLACEHOLDER_RETICULUM_SERVER",
+      THUMBNAIL_SERVER: "__IMMERS_PLACEHOLDER_THUMBNAIL_SERVER",
+      NON_CORS_PROXY_DOMAINS: "__IMMERS_PLACEHOLDER_NON_CORS_PROXY_DOMAINS",
+    };
+  } else {
+    const res = await fetch(`https://${host}/api/ita/configs/hubs`, { headers });
+    hubsConfigs = await res.json();
+    for (const [k, v] of Object.entries(hubsConfigs.general)) {
+      buildEnv[k.toUpperCase()] = v;
+    }
   }
 
   const version = getTs();
 
-  buildEnv.BUILD_VERSION = `1.0.0.${version}`;
+  buildEnv.BUILD_VERSION = `${process.env.npm_package_version}.${version}`;
   buildEnv.ITA_SERVER = "";
   buildEnv.POSTGREST_SERVER = "";
   buildEnv.CONFIGURABLE_SERVICES = "janus-gateway,reticulum,hubs,spoke";
 
   const env = Object.assign(process.env, buildEnv);
+  if (!noBuild) {
+    for (const d in ["./dist", "./admin/dist"]) {
+      rmdir(d, err => {
+        if (err) {
+          console.error(err);
+          process.exit(1);
+        }
+      });
+    }
 
-  for (const d in ["./dist", "./admin/dist"]) {
-    rmdir(d, err => {
-      if (err) {
-        console.error(err);
-        process.exit(1);
+    step.text = "Building Client.";
+
+    await new Promise((resolve, reject) => {
+      if (skipCI) {
+        return resolve();
       }
+      exec("npm ci", {}, err => {
+        if (err) reject(err);
+        resolve();
+      });
+    });
+
+    await new Promise((resolve, reject) => {
+      exec("npm run build", { env }, err => {
+        if (err) reject(err);
+        resolve();
+      });
+    });
+
+    step.text = "Building Admin Console.";
+
+    await new Promise((resolve, reject) => {
+      if (skipCI) {
+        return resolve();
+      }
+      exec("npm ci", { cwd: "./admin" }, err => {
+        if (err) reject(err);
+        resolve();
+      });
+    });
+
+    await new Promise((resolve, reject) => {
+      exec("npm run build", { cwd: "./admin", env }, err => {
+        if (err) reject(err);
+        resolve();
+      });
+    });
+
+    await new Promise(res => {
+      ncp("./admin/dist", "./dist", err => {
+        if (err) {
+          console.error(err);
+          process.exit(1);
+        }
+
+        res();
+      });
     });
   }
-
-  step.text = "Building Client.";
-
-  await new Promise((resolve, reject) => {
-    if (skipCI) {
-      return resolve();
+  if (replacePlaceholders) {
+    // update prebuilt bundle placeholders with server-specific values
+    for (const [k, v] of Object.entries(hubsConfigs.general)) {
+      await new Promise((resolve, reject) => {
+        const ph = v.endsWith("/")
+          // avoid double slash on substitution
+          ? `__IMMERS_PLACEHOLDER_${k.toUpperCase()}/\\?`
+          : `__IMMERS_PLACEHOLDER_${k.toUpperCase()}`;
+        exec(`find ./dist -iregex ".*\\.\\(js\\|html\\|css\\|map\\)" -print0 | xargs -0 sed -i -e 's|${ph}|${v}|g'`, { env }, err => {
+          if (err) reject(err);
+          resolve();
+        });
+      });
     }
-    exec("npm ci", {}, err => {
-      if (err) reject(err);
-      resolve();
-    });
-  });
-
-  await new Promise((resolve, reject) => {
-    exec("npm run build", { env }, err => {
-      if (err) reject(err);
-      resolve();
-    });
-  });
-
-  step.text = "Building Admin Console.";
-
-  await new Promise((resolve, reject) => {
-    if (skipCI) {
-      return resolve();
-    }
-    exec("npm ci", { cwd: "./admin" }, err => {
-      if (err) reject(err);
-      resolve();
-    });
-  });
-
-  await new Promise((resolve, reject) => {
-    exec("npm run build", { cwd: "./admin", env }, err => {
-      if (err) reject(err);
-      resolve();
-    });
-  });
-
-  await new Promise(res => {
-    ncp("./admin/dist", "./dist", err => {
-      if (err) {
-        console.error(err);
-        process.exit(1);
-      }
-
-      res();
-    });
-  });
+  }
+  if (noUpload) {
+    step.text = `Skipping deploy.`;
+    step.succeed();
+    process.exit(0);
+  }
   step.text = "Preparing Deploy.";
 
   step.text = "Packaging Build.";

--- a/scripts/immers-configure.js
+++ b/scripts/immers-configure.js
@@ -20,10 +20,7 @@ const { host, token } = JSON.parse(readFileSync(".ret.credentials"));
   const cfg = {
     extra_csp: {
       // connect to home immer
-      connect_src: "https: wss:",
-      // allow Coil WebMon browser plugin
-      script_src:
-        "'sha256-W5yaJ6UM3/kOJa12aRVSLOEOKdAUYAWZPM1bUuaTJYQ='  'sha256-XpyxuqRQmj1o8ovYZlIA71UXSYTvYdV8kOb55p+lrNo=' 'sha256-tie542PGbiDGOm9MefVIzDBZf4Nt5wTagAHT/BKEB94=' 'sha256-9QLzkf1LE5s0CtnpqUvwkWr7DV4GRfQLGt/tFNT19h0='"
+      connect_src: "https: wss:"
     },
     security: {
       // fetch remote avatars
@@ -35,7 +32,7 @@ const { host, token } = JSON.parse(readFileSync(".ret.credentials"));
     },
     extra_html: {}
   };
-  // add local immers server env variable and web monetizatoin payment pointer to all pages
+  // add local immers server env variable and web monetization payment pointer to all pages
   const extraHeader = `<meta name="env:immers_server" content="https://${immer}"><meta name="monetization" content="${wallet}">`;
   ["extra_avatar_html", "extra_index_html", "extra_room_html", "extra_scene_html"].forEach(setting => {
     cfg.extra_html[setting] = extraHeader;

--- a/src/utils/immers/monetization.js
+++ b/src/utils/immers/monetization.js
@@ -74,6 +74,12 @@ export function setupMonetization(scene, player, remountUI) {
   if (hubScene.is("loaded")) {
     onSceneLoaded();
   } else {
-    hubScene.addEventListener("environment-scene-loaded", onSceneLoaded, { once: true });
+    const sceneStateListener = ({ detail }) => {
+      if (detail === "loaded") {
+        onSceneLoaded();
+        hubScene.removeEventListener("stateadded", sceneStateListener);
+      }
+    };
+    hubScene.addEventListener("stateadded", sceneStateListener);
   }
 }


### PR DESCRIPTION
The prior docker-compose hubdeployer in [immers-app](https://github.com/immers-space/immers-app) didn't really work because it required running the Hubs webpack build on the cloud server and that required > 4GB RAM, which is a way costlier box that is necessary for the Immers server. The reason for this requirement of building in-place is the Hubs build bakes in some static strings related to the specific Hubs cloud it is going to be deployed to. 

Now, we have a prebuilt bundle that can be deployed to multiple hubs without running webpack so it can run on a simple 1GB RAM Immers server. Here's how:
* Break up the `deploy.js`  Hubs script to be able to run different parts at different times via CLI args
* For the docker image, run the build with placeholder strings inserted for all of the build config options
* In the docker deploy script, do string substitution on the built files to sub in the specific Hubs cloud values for the placeholders, and then deploy it to the Hubs cloud

# Web Monetization update

New version of the Coil plugin has dropped, so we update our `web-monetizatoin-polyfill` to the newer, compatible version, and we no longer needs to add CSP `script-src` hashes. Also finally tracked down an issue where the Immers monetization initialization code would sometimes never get run, leaving the app in a invalid monetization state.